### PR TITLE
feat: 혀 훈련 MVP 앱 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+coverage/
+.DS_Store
+*.log

--- a/icons/icon.svg
+++ b/icons/icon.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="50%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#ec4899"/>
+    </linearGradient>
+    <linearGradient id="tongueGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#ff6b9d"/>
+      <stop offset="100%" style="stop-color:#c44569"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#bgGrad)"/>
+
+  <!-- Inner glow -->
+  <circle cx="256" cy="256" r="200" fill="rgba(255,255,255,0.1)"/>
+
+  <!-- Mouth outline -->
+  <ellipse cx="256" cy="280" rx="120" ry="100" fill="rgba(0,0,0,0.3)" stroke="rgba(255,255,255,0.3)" stroke-width="4"/>
+
+  <!-- Tongue -->
+  <path d="M 180 260
+           Q 180 320, 220 360
+           Q 256 400, 292 360
+           Q 332 320, 332 260
+           Q 332 220, 256 200
+           Q 180 220, 180 260 Z"
+        fill="url(#tongueGrad)"
+        stroke="rgba(255,255,255,0.4)"
+        stroke-width="3"/>
+
+  <!-- Tongue center line -->
+  <path d="M 256 220 Q 256 300, 256 370"
+        stroke="rgba(0,0,0,0.2)"
+        stroke-width="4"
+        fill="none"
+        stroke-linecap="round"/>
+
+  <!-- Sparkles -->
+  <circle cx="160" cy="160" r="12" fill="rgba(255,255,255,0.8)"/>
+  <circle cx="140" cy="190" r="6" fill="rgba(255,255,255,0.5)"/>
+  <circle cx="360" cy="140" r="8" fill="rgba(255,255,255,0.6)"/>
+
+  <!-- Strength indicator bars -->
+  <rect x="100" y="420" width="60" height="12" rx="6" fill="rgba(255,255,255,0.3)"/>
+  <rect x="180" y="420" width="60" height="12" rx="6" fill="rgba(255,255,255,0.5)"/>
+  <rect x="260" y="420" width="60" height="12" rx="6" fill="rgba(255,255,255,0.7)"/>
+  <rect x="340" y="420" width="60" height="12" rx="6" fill="rgba(255,255,255,0.9)"/>
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,43 @@
+{
+  "name": "혀 훈련 - Tongue Training",
+  "short_name": "혀 훈련",
+  "description": "8주 혀 근력 강화 프로그램 - 수면무호흡 개선을 위한 과학적 훈련",
+  "start_url": "/tongue-training.html",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "theme_color": "#0a0a0f",
+  "background_color": "#0a0a0f",
+  "lang": "ko",
+  "categories": ["health", "fitness", "lifestyle"],
+  "icons": [
+    {
+      "src": "icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "훈련 시작",
+      "short_name": "훈련",
+      "description": "바로 훈련 시작하기",
+      "url": "/tongue-training.html#training",
+      "icons": [{ "src": "icons/icon.svg", "sizes": "any", "type": "image/svg+xml" }]
+    },
+    {
+      "name": "통계 보기",
+      "short_name": "통계",
+      "description": "훈련 통계 확인",
+      "url": "/tongue-training.html#dashboard",
+      "icons": [{ "src": "icons/icon.svg", "sizes": "any", "type": "image/svg+xml" }]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3061 @@
+{
+  "name": "tongue-training-pwa",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tongue-training-pwa",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^2.0.0",
+        "jsdom": "^24.0.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tongue-training-pwa",
+  "version": "1.0.0",
+  "description": "8주 혀 근력 강화 프로그램 PWA",
+  "type": "module",
+  "scripts": {
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:coverage": "vitest --coverage",
+    "test:ui": "vitest --ui"
+  },
+  "devDependencies": {
+    "vitest": "^2.0.0",
+    "jsdom": "^24.0.0",
+    "@vitest/coverage-v8": "^2.0.0"
+  }
+}

--- a/src/gamification/badges.js
+++ b/src/gamification/badges.js
@@ -1,0 +1,148 @@
+/**
+ * 배지 시스템
+ * 8개의 배지와 획득 조건 정의
+ */
+
+export const BADGES = [
+  { id: 'first_step',    emoji: '🌱', name: '첫 걸음',     description: '첫 훈련 완료' },
+  { id: 'week_warrior',  emoji: '⚔️', name: '일주일 전사', description: '7일 연속 훈련' },
+  { id: 'month_miracle', emoji: '🏆', name: '한 달의 기적', description: '30일 연속 훈련' },
+  { id: 'morning_bird',  emoji: '🌅', name: '아침형 인간', description: '오전 6-9시 훈련 10회' },
+  { id: 'night_owl',     emoji: '🦉', name: '올빼미',       description: '밤 9시 후 훈련 10회' },
+  { id: 'sleep_master',  emoji: '😴', name: '수면 마스터', description: '7시간+ 수면 후 훈련 10회' },
+  { id: 'century',       emoji: '💯', name: '100회 달성',  description: '총 100회 훈련' },
+  { id: 'champion',      emoji: '👑', name: '혀 근력왕',   description: '8주 프로그램 완주' }
+];
+
+/**
+ * 배지 ID로 배지 정보 조회
+ * @param {string} badgeId
+ * @returns {Object|null}
+ */
+export function getBadgeById(badgeId) {
+  return BADGES.find(b => b.id === badgeId) || null;
+}
+
+/**
+ * 사용자 통계 기반으로 획득 가능한 배지 계산
+ * @param {Object} stats - 사용자 통계
+ * @param {number} stats.totalSessions - 총 세션 수
+ * @param {number} stats.maxStreak - 최장 연속일
+ * @param {number} stats.morningCount - 아침 훈련 횟수 (6-9시)
+ * @param {number} stats.eveningCount - 저녁 훈련 횟수 (21시 이후)
+ * @param {number} stats.goodSleepCount - 7시간+ 수면 후 훈련 횟수
+ * @param {number} stats.programWeeks - 완료한 프로그램 주차
+ * @returns {string[]} 획득 가능한 배지 ID 배열
+ */
+export function getEarnedBadges(stats) {
+  const earned = [];
+
+  if (stats.totalSessions >= 1) earned.push('first_step');
+  if (stats.maxStreak >= 7) earned.push('week_warrior');
+  if (stats.maxStreak >= 30) earned.push('month_miracle');
+  if (stats.morningCount >= 10) earned.push('morning_bird');
+  if (stats.eveningCount >= 10) earned.push('night_owl');
+  if (stats.goodSleepCount >= 10) earned.push('sleep_master');
+  if (stats.totalSessions >= 100) earned.push('century');
+  if (stats.programWeeks >= 8) earned.push('champion');
+
+  return earned;
+}
+
+/**
+ * 새로 획득한 배지 확인
+ * @param {string[]} currentBadges - 현재 보유 배지
+ * @param {string[]} earnedBadges - 획득 가능한 배지
+ * @returns {string[]} 새로 획득한 배지 ID 배열
+ */
+export function getNewBadges(currentBadges, earnedBadges) {
+  return earnedBadges.filter(b => !currentBadges.includes(b));
+}
+
+/**
+ * 히스토리에서 배지 관련 통계 계산
+ * @param {Array} history - 세션 히스토리
+ * @param {Object} sleepData - 수면 데이터 { [date]: { hours } }
+ * @param {number} maxStreak - 최장 연속일
+ * @returns {Object} 배지용 통계
+ */
+export function calculateBadgeStats(history, sleepData = {}, maxStreak = 0) {
+  let morningCount = 0;
+  let eveningCount = 0;
+  let goodSleepCount = 0;
+
+  history.forEach(session => {
+    const hour = new Date(session.timestamp).getHours();
+
+    // 아침 (6-9시)
+    if (hour >= 6 && hour < 9) {
+      morningCount++;
+    }
+
+    // 저녁 (21시 이후)
+    if (hour >= 21 || hour < 5) {
+      eveningCount++;
+    }
+
+    // 7시간+ 수면 후 훈련
+    const sleep = sleepData[session.date];
+    if (sleep && parseFloat(sleep.hours) >= 7) {
+      goodSleepCount++;
+    }
+  });
+
+  // 프로그램 주차 계산 (첫 훈련 날짜 기준)
+  let programWeeks = 0;
+  if (history.length > 0) {
+    const sortedDates = [...new Set(history.map(s => s.date))].sort();
+    const firstDate = new Date(sortedDates[0]);
+    const lastDate = new Date(sortedDates[sortedDates.length - 1]);
+    const daysDiff = Math.floor((lastDate - firstDate) / (1000 * 60 * 60 * 24));
+    programWeeks = Math.floor(daysDiff / 7) + 1;
+  }
+
+  return {
+    totalSessions: history.length,
+    maxStreak,
+    morningCount,
+    eveningCount,
+    goodSleepCount,
+    programWeeks
+  };
+}
+
+/**
+ * 프로필에서 배지 저장/로드
+ */
+const PROFILE_KEY = 'tongueProfile';
+
+export function loadProfile(storage = localStorage) {
+  const data = storage.getItem(PROFILE_KEY);
+  if (!data) {
+    return { xp: 0, level: 1, badges: [], badgeNotified: [] };
+  }
+  return JSON.parse(data);
+}
+
+export function saveProfile(profile, storage = localStorage) {
+  storage.setItem(PROFILE_KEY, JSON.stringify(profile));
+}
+
+/**
+ * 배지 업데이트 (새 배지 획득 시 프로필 저장)
+ * @param {Object} stats - 사용자 통계
+ * @param {Storage} storage
+ * @returns {Object} { newBadges: string[], profile: Object }
+ */
+export function updateBadges(stats, storage = localStorage) {
+  const profile = loadProfile(storage);
+  const earnedBadges = getEarnedBadges(stats);
+  const newBadges = getNewBadges(profile.badges, earnedBadges);
+
+  if (newBadges.length > 0) {
+    profile.badges = earnedBadges;
+    saveProfile(profile, storage);
+  }
+
+  return { newBadges, profile };
+}

--- a/src/gamification/level.js
+++ b/src/gamification/level.js
@@ -1,0 +1,156 @@
+/**
+ * XP 및 레벨 시스템
+ */
+
+// XP 획득량
+export const XP_VALUES = {
+  SESSION_COMPLETE: 50,    // 훈련 완료
+  FULL_COMPLETE_BONUS: 20, // 완주 보너스 (35회 완료)
+  STREAK_MULTIPLIER: 5,    // 연속일 × 5
+  BADGE_EARNED: 100        // 배지 획득
+};
+
+// 레벨 테이블
+export const LEVEL_THRESHOLDS = [
+  // Level 1-5: 100 XP/Lv (초보자)
+  { level: 1, xpRequired: 0, tier: '초보자' },
+  { level: 2, xpRequired: 100, tier: '초보자' },
+  { level: 3, xpRequired: 200, tier: '초보자' },
+  { level: 4, xpRequired: 300, tier: '초보자' },
+  { level: 5, xpRequired: 400, tier: '초보자' },
+  // Level 6-10: 200 XP/Lv (중급자)
+  { level: 6, xpRequired: 500, tier: '중급자' },
+  { level: 7, xpRequired: 700, tier: '중급자' },
+  { level: 8, xpRequired: 900, tier: '중급자' },
+  { level: 9, xpRequired: 1100, tier: '중급자' },
+  { level: 10, xpRequired: 1300, tier: '중급자' },
+  // Level 11-20: 300 XP/Lv (숙련자)
+  { level: 11, xpRequired: 1500, tier: '숙련자' },
+  { level: 12, xpRequired: 1800, tier: '숙련자' },
+  { level: 13, xpRequired: 2100, tier: '숙련자' },
+  { level: 14, xpRequired: 2400, tier: '숙련자' },
+  { level: 15, xpRequired: 2700, tier: '숙련자' },
+  { level: 16, xpRequired: 3000, tier: '숙련자' },
+  { level: 17, xpRequired: 3300, tier: '숙련자' },
+  { level: 18, xpRequired: 3600, tier: '숙련자' },
+  { level: 19, xpRequired: 3900, tier: '숙련자' },
+  { level: 20, xpRequired: 4200, tier: '숙련자' },
+  // Level 21+: 500 XP/Lv (마스터)
+  { level: 21, xpRequired: 4500, tier: '마스터' }
+];
+
+/**
+ * XP로 레벨 계산
+ * @param {number} xp - 총 XP
+ * @returns {Object} { level, tier, currentXp, nextLevelXp, progress }
+ */
+export function calculateLevel(xp) {
+  let levelInfo = LEVEL_THRESHOLDS[0];
+
+  for (let i = LEVEL_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (xp >= LEVEL_THRESHOLDS[i].xpRequired) {
+      levelInfo = LEVEL_THRESHOLDS[i];
+      break;
+    }
+  }
+
+  // 다음 레벨까지 필요한 XP 계산
+  let nextLevelXp;
+  const currentLevelIndex = LEVEL_THRESHOLDS.findIndex(t => t.level === levelInfo.level);
+
+  if (currentLevelIndex < LEVEL_THRESHOLDS.length - 1) {
+    nextLevelXp = LEVEL_THRESHOLDS[currentLevelIndex + 1].xpRequired;
+  } else {
+    // 레벨 21 이상: 500 XP씩 증가
+    const levelsAbove21 = levelInfo.level - 21;
+    const currentThreshold = 4500 + (levelsAbove21 * 500);
+    nextLevelXp = currentThreshold + 500;
+
+    // 실제 레벨 재계산 (21 이상)
+    if (xp >= 4500) {
+      const xpAbove21 = xp - 4500;
+      const extraLevels = Math.floor(xpAbove21 / 500);
+      levelInfo = {
+        level: 21 + extraLevels,
+        tier: '마스터',
+        xpRequired: 4500 + (extraLevels * 500)
+      };
+      nextLevelXp = levelInfo.xpRequired + 500;
+    }
+  }
+
+  const currentXp = xp - levelInfo.xpRequired;
+  const xpForNextLevel = nextLevelXp - levelInfo.xpRequired;
+  const progress = xpForNextLevel > 0 ? currentXp / xpForNextLevel : 1;
+
+  return {
+    level: levelInfo.level,
+    tier: levelInfo.tier,
+    totalXp: xp,
+    currentXp,
+    nextLevelXp,
+    xpForNextLevel,
+    progress: Math.min(progress, 1)
+  };
+}
+
+/**
+ * 세션 완료 시 획득 XP 계산
+ * @param {Object} options
+ * @param {boolean} options.completed - 완주 여부 (35회)
+ * @param {number} options.streak - 현재 연속일
+ * @param {number} options.newBadgeCount - 새로 획득한 배지 수
+ * @returns {Object} { total, breakdown }
+ */
+export function calculateSessionXp({ completed = false, streak = 0, newBadgeCount = 0 }) {
+  const breakdown = {
+    base: XP_VALUES.SESSION_COMPLETE,
+    completionBonus: completed ? XP_VALUES.FULL_COMPLETE_BONUS : 0,
+    streakBonus: streak * XP_VALUES.STREAK_MULTIPLIER,
+    badgeBonus: newBadgeCount * XP_VALUES.BADGE_EARNED
+  };
+
+  const total = Object.values(breakdown).reduce((sum, val) => sum + val, 0);
+
+  return { total, breakdown };
+}
+
+/**
+ * XP 추가 및 레벨업 확인
+ * @param {number} currentXp - 현재 XP
+ * @param {number} gainedXp - 획득한 XP
+ * @returns {Object} { newXp, oldLevel, newLevel, leveledUp }
+ */
+export function addXp(currentXp, gainedXp) {
+  const oldLevelInfo = calculateLevel(currentXp);
+  const newXp = currentXp + gainedXp;
+  const newLevelInfo = calculateLevel(newXp);
+
+  return {
+    newXp,
+    oldLevel: oldLevelInfo.level,
+    newLevel: newLevelInfo.level,
+    leveledUp: newLevelInfo.level > oldLevelInfo.level,
+    levelsGained: newLevelInfo.level - oldLevelInfo.level
+  };
+}
+
+/**
+ * 레벨 정보 조회
+ * @param {number} level
+ * @returns {Object|null}
+ */
+export function getLevelInfo(level) {
+  if (level <= 0) return null;
+
+  if (level <= 20) {
+    return LEVEL_THRESHOLDS.find(t => t.level === level) || null;
+  }
+
+  // 레벨 21 이상
+  return {
+    level,
+    xpRequired: 4500 + ((level - 21) * 500),
+    tier: '마스터'
+  };
+}

--- a/src/gamification/milestones.js
+++ b/src/gamification/milestones.js
@@ -1,0 +1,122 @@
+/**
+ * 마일스톤 시스템
+ * 특정 달성 시점에 축하 메시지/모달 표시
+ */
+
+// 연속일 마일스톤
+export const STREAK_MILESTONES = [
+  { days: 3,  emoji: '🔥', message: '3일 연속 달성!', description: '습관의 시작이에요' },
+  { days: 7,  emoji: '⚔️', message: '일주일 전사!', description: '꾸준히 잘하고 있어요' },
+  { days: 14, emoji: '🌟', message: '2주 연속!', description: '습관이 자리잡고 있어요' },
+  { days: 21, emoji: '💪', message: '21일 습관 형성!', description: '이제 몸이 기억해요' },
+  { days: 30, emoji: '🏆', message: '한 달의 기적!', description: '대단해요!' },
+  { days: 60, emoji: '👑', message: '60일 마스터!', description: '진정한 혀 근력왕' },
+  { days: 100, emoji: '💯', message: '100일 전설!', description: '당신은 전설입니다' }
+];
+
+// 세션 수 마일스톤
+export const SESSION_MILESTONES = [
+  { count: 1,   emoji: '🌱', message: '첫 훈련 완료!', description: '여정이 시작되었어요' },
+  { count: 10,  emoji: '⭐', message: '10회 달성!', description: '점점 익숙해지고 있어요' },
+  { count: 25,  emoji: '🎯', message: '25회 달성!', description: '꾸준함이 빛나요' },
+  { count: 50,  emoji: '🎖️', message: '50회 달성!', description: '절반 왔어요!' },
+  { count: 100, emoji: '💯', message: '100회 달성!', description: '세 자릿수 돌파!' },
+  { count: 365, emoji: '🎊', message: '1년치 훈련!', description: '365회, 놀라워요!' }
+];
+
+// 레벨업 메시지
+export const LEVEL_UP_MESSAGES = {
+  '초보자': { emoji: '🌱', message: '성장하고 있어요!' },
+  '중급자': { emoji: '⭐', message: '중급자로 승급!' },
+  '숙련자': { emoji: '💪', message: '숙련자의 영역!' },
+  '마스터': { emoji: '👑', message: '마스터 등극!' }
+};
+
+/**
+ * 연속일 마일스톤 확인
+ * @param {number} streak - 현재 연속일
+ * @returns {Object|null} 달성한 마일스톤 또는 null
+ */
+export function checkStreakMilestone(streak) {
+  return STREAK_MILESTONES.find(m => m.days === streak) || null;
+}
+
+/**
+ * 세션 수 마일스톤 확인
+ * @param {number} sessionCount - 총 세션 수
+ * @returns {Object|null} 달성한 마일스톤 또는 null
+ */
+export function checkSessionMilestone(sessionCount) {
+  return SESSION_MILESTONES.find(m => m.count === sessionCount) || null;
+}
+
+/**
+ * 레벨업 메시지 조회
+ * @param {number} oldLevel
+ * @param {number} newLevel
+ * @param {string} newTier
+ * @returns {Object} { leveledUp, message, tierChanged, tierMessage }
+ */
+export function getLevelUpMessage(oldLevel, newLevel, newTier) {
+  const leveledUp = newLevel > oldLevel;
+  const tierMessage = LEVEL_UP_MESSAGES[newTier] || LEVEL_UP_MESSAGES['초보자'];
+
+  // 티어 변경 확인
+  const oldTierThresholds = [1, 6, 11, 21];
+  const oldTierIndex = oldTierThresholds.filter(t => oldLevel >= t).length - 1;
+  const newTierIndex = oldTierThresholds.filter(t => newLevel >= t).length - 1;
+  const tierChanged = newTierIndex > oldTierIndex;
+
+  return {
+    leveledUp,
+    newLevel,
+    message: leveledUp ? `레벨 ${newLevel} 달성!` : null,
+    tierChanged,
+    tierMessage: tierChanged ? tierMessage : null
+  };
+}
+
+/**
+ * 모든 달성 이벤트 확인 (세션 완료 후 호출)
+ * @param {Object} params
+ * @param {number} params.streak - 현재 연속일
+ * @param {number} params.sessionCount - 총 세션 수
+ * @param {number} params.oldLevel - 이전 레벨
+ * @param {number} params.newLevel - 새 레벨
+ * @param {string} params.newTier - 새 티어
+ * @param {string[]} params.newBadges - 새로 획득한 배지 ID
+ * @returns {Object} { streakMilestone, sessionMilestone, levelUp, newBadges }
+ */
+export function checkAllMilestones({
+  streak = 0,
+  sessionCount = 0,
+  oldLevel = 1,
+  newLevel = 1,
+  newTier = '초보자',
+  newBadges = []
+}) {
+  return {
+    streakMilestone: checkStreakMilestone(streak),
+    sessionMilestone: checkSessionMilestone(sessionCount),
+    levelUp: getLevelUpMessage(oldLevel, newLevel, newTier),
+    newBadges
+  };
+}
+
+/**
+ * 다음 마일스톤까지 남은 일수/횟수 계산
+ * @param {number} current - 현재 값
+ * @param {Array} milestones - 마일스톤 배열
+ * @param {string} key - 비교할 키 (days 또는 count)
+ * @returns {Object|null} { next, remaining }
+ */
+export function getNextMilestone(current, milestones, key) {
+  const upcoming = milestones.filter(m => m[key] > current);
+  if (upcoming.length === 0) return null;
+
+  const next = upcoming[0];
+  return {
+    next,
+    remaining: next[key] - current
+  };
+}

--- a/src/stats/calculations.js
+++ b/src/stats/calculations.js
@@ -1,0 +1,238 @@
+/**
+ * 통계 계산 함수 (순수 함수)
+ * DOM 의존성 없이 데이터만 처리
+ */
+
+/**
+ * 기본 통계 계산
+ * @param {Array} history - 세션 히스토리
+ * @returns {Object} { uniqueDays, totalReps, totalMinutes, maxStreak }
+ */
+export function calculateStats(history) {
+  if (!history || history.length === 0) {
+    return { uniqueDays: 0, totalReps: 0, totalMinutes: 0, maxStreak: 0 };
+  }
+
+  const uniqueDays = new Set(history.map(s => s.date)).size;
+  const totalReps = history.reduce((sum, s) => sum + (s.reps || 0), 0);
+  const totalSeconds = history.reduce((sum, s) => sum + (s.duration || 0), 0);
+  const totalMinutes = Math.round(totalSeconds / 60);
+  const maxStreak = calculateMaxStreak(history);
+
+  return { uniqueDays, totalReps, totalMinutes, maxStreak };
+}
+
+/**
+ * 최장 연속일 계산
+ * @param {Array} history - 세션 히스토리
+ * @returns {number} 최장 연속일
+ */
+export function calculateMaxStreak(history) {
+  if (!history || history.length === 0) return 0;
+
+  const dates = [...new Set(history.map(s => s.date))].sort();
+  let maxStreak = 0;
+  let currentStreak = 0;
+  let prevDate = null;
+
+  for (const dateStr of dates) {
+    const d = new Date(dateStr);
+    if (prevDate) {
+      const diff = (d - prevDate) / (1000 * 60 * 60 * 24);
+      if (diff === 1) {
+        currentStreak++;
+      } else {
+        currentStreak = 1;
+      }
+    } else {
+      currentStreak = 1;
+    }
+    maxStreak = Math.max(maxStreak, currentStreak);
+    prevDate = d;
+  }
+
+  return maxStreak;
+}
+
+/**
+ * 히트맵 데이터 계산 (날짜별 세션 수)
+ * @param {Array} history
+ * @returns {Object} { [date]: count }
+ */
+export function calculateHeatmapData(history) {
+  const dayCounts = {};
+  history.forEach(s => {
+    dayCounts[s.date] = (dayCounts[s.date] || 0) + 1;
+  });
+  return dayCounts;
+}
+
+/**
+ * 주간 데이터 계산
+ * @param {Array} history
+ * @param {number} now - 현재 타임스탬프
+ * @returns {Object} { weekData, weekRange, maxMinutes }
+ */
+export function calculateWeeklyData(history, now = Date.now()) {
+  const today = new Date(now);
+  const dayOfWeek = today.getDay() || 7; // 일요일(0) -> 7
+  const monday = new Date(today);
+  monday.setDate(today.getDate() - dayOfWeek + 1);
+  monday.setHours(0, 0, 0, 0);
+
+  const days = ['월', '화', '수', '목', '금', '토', '일'];
+  const weekData = [];
+  let maxMinutes = 0;
+
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(monday);
+    d.setDate(monday.getDate() + i);
+    const dateStr = d.toISOString().split('T')[0];
+    const sessions = history.filter(s => s.date === dateStr);
+    const totalMin = Math.round(sessions.reduce((sum, s) => sum + (s.duration || 0), 0) / 60);
+
+    maxMinutes = Math.max(maxMinutes, totalMin);
+
+    weekData.push({
+      day: days[i],
+      date: dateStr,
+      minutes: totalMin,
+      isToday: dateStr === today.toISOString().split('T')[0]
+    });
+  }
+
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const weekRange = `${monday.getMonth() + 1}/${monday.getDate()} - ${sunday.getMonth() + 1}/${sunday.getDate()}`;
+
+  return { weekData, weekRange, maxMinutes };
+}
+
+/**
+ * 수면-훈련 인사이트 계산
+ * @param {Array} history - 세션 히스토리
+ * @param {Object} sleepData - { [date]: { hours, quality } }
+ * @param {number} totalReps - 완주 기준 반복 횟수 (기본 35)
+ * @returns {Object}
+ */
+export function calculateSleepInsight(history, sleepData, totalReps = 35) {
+  const sessionsWithSleep = history.filter(s => {
+    const sleep = sleepData[s.date];
+    return sleep && sleep.hours;
+  });
+
+  if (sessionsWithSleep.length < 3) {
+    return { hasEnoughData: false };
+  }
+
+  let goodSleepDays = 0, goodSleepComplete = 0;
+  let badSleepDays = 0, badSleepComplete = 0;
+
+  sessionsWithSleep.forEach(s => {
+    const sleep = sleepData[s.date];
+    const hours = parseFloat(sleep.hours) || 0;
+    if (hours >= 7) {
+      goodSleepDays++;
+      if ((s.reps || 0) >= totalReps) goodSleepComplete++;
+    } else {
+      badSleepDays++;
+      if ((s.reps || 0) >= totalReps) badSleepComplete++;
+    }
+  });
+
+  const goodRate = goodSleepDays > 0 ? Math.round((goodSleepComplete / goodSleepDays) * 100) : 0;
+  const badRate = badSleepDays > 0 ? Math.round((badSleepComplete / badSleepDays) * 100) : 0;
+
+  return {
+    hasEnoughData: true,
+    goodSleepDays,
+    badSleepDays,
+    goodRate,
+    badRate,
+    diff: goodRate - badRate
+  };
+}
+
+/**
+ * 최적 훈련 시간대 계산
+ * @param {Array} history
+ * @param {number} totalReps - 완주 기준
+ * @returns {Object}
+ */
+export function calculateBestTrainingTime(history, totalReps = 35) {
+  const timeSlots = { morning: [], afternoon: [], evening: [] };
+
+  history.forEach(s => {
+    const h = new Date(s.timestamp).getHours();
+    const completed = (s.reps || 0) >= totalReps;
+
+    if (h >= 5 && h < 12) {
+      timeSlots.morning.push(completed);
+    } else if (h >= 12 && h < 18) {
+      timeSlots.afternoon.push(completed);
+    } else {
+      timeSlots.evening.push(completed);
+    }
+  });
+
+  const getRate = arr => arr.length > 0 ? arr.filter(x => x).length / arr.length : 0;
+
+  const rates = {
+    morning: { rate: getRate(timeSlots.morning), count: timeSlots.morning.length },
+    afternoon: { rate: getRate(timeSlots.afternoon), count: timeSlots.afternoon.length },
+    evening: { rate: getRate(timeSlots.evening), count: timeSlots.evening.length }
+  };
+
+  let bestTime = 'morning';
+  let bestRate = rates.morning.rate;
+
+  if (rates.afternoon.rate > bestRate) {
+    bestTime = 'afternoon';
+    bestRate = rates.afternoon.rate;
+  }
+  if (rates.evening.rate > bestRate) {
+    bestTime = 'evening';
+    bestRate = rates.evening.rate;
+  }
+
+  const timeLabels = {
+    morning: '아침 (5-12시)',
+    afternoon: '오후 (12-18시)',
+    evening: '저녁/밤 (18-5시)'
+  };
+
+  return {
+    bestTime,
+    bestTimeLabel: timeLabels[bestTime],
+    bestRate: Math.round(bestRate * 100),
+    rates
+  };
+}
+
+/**
+ * 상관관계 차트 데이터 계산
+ * @param {Array} history
+ * @param {Object} sleepData
+ * @param {number} totalReps
+ * @returns {Array} [{ x, y, completed, date }]
+ */
+export function calculateCorrelationData(history, sleepData, totalReps = 35) {
+  return history
+    .filter(s => sleepData[s.date] && sleepData[s.date].hours)
+    .map(s => {
+      const sleep = sleepData[s.date];
+      const hours = parseFloat(sleep.hours) || 0;
+      const minutes = Math.round((s.duration || 0) / 60);
+      const completed = (s.reps || 0) >= totalReps;
+
+      return {
+        date: s.date,
+        sleepHours: hours,
+        trainingMinutes: minutes,
+        completed,
+        // 좌표 계산 (수면 4-10시간, 훈련 0-15분 기준)
+        x: Math.min(Math.max((hours - 4) / 6, 0), 1),
+        y: Math.min(minutes / 15, 1)
+      };
+    });
+}

--- a/src/sw/helpers.js
+++ b/src/sw/helpers.js
@@ -1,0 +1,96 @@
+/**
+ * Service Worker 헬퍼 함수
+ */
+
+// 정적 리소스 목록
+export const STATIC_ASSETS = [
+  '/',
+  '/tongue-training.html',
+  '/manifest.json',
+  '/icons/icon.svg'
+];
+
+// 외부 리소스 패턴
+export const EXTERNAL_PATTERNS = [
+  'fonts.googleapis.com',
+  'fonts.gstatic.com',
+  'unpkg.com/@splinetool'
+];
+
+/**
+ * 정적 리소스 여부 확인
+ * @param {string} pathname - URL 경로
+ * @param {string[]} staticAssets - 정적 리소스 목록 (테스트용)
+ * @returns {boolean}
+ */
+export function isStaticAsset(pathname, staticAssets = STATIC_ASSETS) {
+  return staticAssets.includes(pathname) ||
+         pathname.endsWith('.html') ||
+         pathname.endsWith('.css') ||
+         pathname.endsWith('.js') ||
+         pathname.endsWith('.svg') ||
+         pathname.endsWith('.png') ||
+         pathname.endsWith('.ico');
+}
+
+/**
+ * 외부 리소스 여부 확인
+ * @param {string} url - 전체 URL
+ * @param {string[]} patterns - 외부 리소스 패턴 (테스트용)
+ * @returns {boolean}
+ */
+export function isExternalResource(url, patterns = EXTERNAL_PATTERNS) {
+  return patterns.some(pattern => url.includes(pattern));
+}
+
+/**
+ * 오프라인 응답 HTML 생성
+ * @returns {string}
+ */
+export function getOfflineHtml() {
+  return `
+    <!DOCTYPE html>
+    <html lang="ko">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>오프라인 - 혀 훈련</title>
+      <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+          background: linear-gradient(135deg, #0a0a0f 0%, #1a1a2e 100%);
+          color: #fff;
+          min-height: 100vh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          text-align: center;
+          padding: 20px;
+        }
+        .offline-container { max-width: 400px; }
+        .offline-icon { font-size: 64px; margin-bottom: 24px; }
+        h1 { font-size: 24px; margin-bottom: 12px; }
+        p { color: rgba(255,255,255,0.6); margin-bottom: 24px; line-height: 1.6; }
+        button {
+          background: linear-gradient(135deg, #6366f1, #8b5cf6);
+          color: #fff;
+          border: none;
+          padding: 12px 24px;
+          border-radius: 12px;
+          font-size: 16px;
+          cursor: pointer;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="offline-container">
+        <div class="offline-icon">📶</div>
+        <h1>오프라인 상태입니다</h1>
+        <p>인터넷 연결을 확인해주세요.</p>
+        <button onclick="location.reload()">다시 시도</button>
+      </div>
+    </body>
+    </html>
+  `;
+}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,54 @@
+/**
+ * 날짜 유틸리티 함수
+ * 테스트 용이성을 위해 now 파라미터로 현재 시간 주입 가능
+ */
+
+/**
+ * 오늘 날짜를 ISO 형식으로 반환 (YYYY-MM-DD)
+ * @param {number} now - 현재 타임스탬프 (기본: Date.now())
+ * @returns {string} YYYY-MM-DD 형식 날짜
+ */
+export function getToday(now = Date.now()) {
+  return new Date(now).toISOString().split('T')[0];
+}
+
+/**
+ * 오늘 날짜를 문자열로 반환 (예: "Wed Mar 11 2026")
+ * @param {number} now - 현재 타임스탬프
+ * @returns {string} Date.toDateString() 형식
+ */
+export function getTodayString(now = Date.now()) {
+  return new Date(now).toDateString();
+}
+
+/**
+ * 어제 날짜를 문자열로 반환
+ * @param {number} now - 현재 타임스탬프
+ * @returns {string} Date.toDateString() 형식
+ */
+export function getYesterdayString(now = Date.now()) {
+  return new Date(now - 86400000).toDateString();
+}
+
+/**
+ * 두 날짜 사이의 일수 차이 계산
+ * @param {string} date1 - 첫 번째 날짜 (YYYY-MM-DD)
+ * @param {string} date2 - 두 번째 날짜 (YYYY-MM-DD)
+ * @returns {number} 일수 차이
+ */
+export function getDaysDiff(date1, date2) {
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  const diffTime = Math.abs(d2 - d1);
+  return Math.floor(diffTime / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * 날짜가 연속인지 확인 (하루 차이)
+ * @param {string} date1 - 이전 날짜 (YYYY-MM-DD)
+ * @param {string} date2 - 이후 날짜 (YYYY-MM-DD)
+ * @returns {boolean}
+ */
+export function isConsecutive(date1, date2) {
+  return getDaysDiff(date1, date2) === 1;
+}

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -1,0 +1,74 @@
+/**
+ * 세션 히스토리 관리 함수
+ */
+
+import { getToday } from './date.js';
+import { getTodaySleep } from './sleep.js';
+
+const STORAGE_KEY = 'tongueHistory';
+
+/**
+ * 모든 세션 히스토리 조회
+ * @param {Storage} storage - localStorage 또는 mock
+ * @returns {Array} 세션 배열
+ */
+export function getHistory(storage = localStorage) {
+  return JSON.parse(storage.getItem(STORAGE_KEY) || '[]');
+}
+
+/**
+ * 세션 저장
+ * @param {number} duration - 훈련 시간 (초)
+ * @param {number} reps - 완료한 반복 횟수
+ * @param {Storage} storage
+ * @param {number} now - 현재 타임스탬프
+ * @returns {Object} 저장된 세션 객체
+ */
+export function saveSession(duration, reps, storage = localStorage, now = Date.now()) {
+  const history = getHistory(storage);
+  const today = getToday(now);
+  const session = {
+    date: today,
+    timestamp: now,
+    duration,
+    reps,
+    sleep: getTodaySleep(storage, now)
+  };
+  history.push(session);
+  storage.setItem(STORAGE_KEY, JSON.stringify(history));
+  return session;
+}
+
+/**
+ * 특정 날짜의 세션들 조회
+ * @param {string} date - YYYY-MM-DD 형식
+ * @param {Storage} storage
+ * @returns {Array} 해당 날짜의 세션 배열
+ */
+export function getSessionsByDate(date, storage = localStorage) {
+  const history = getHistory(storage);
+  return history.filter(session => session.date === date);
+}
+
+/**
+ * 최근 N일간의 세션 조회
+ * @param {number} days - 일수
+ * @param {Storage} storage
+ * @param {number} now
+ * @returns {Array} 세션 배열
+ */
+export function getRecentSessions(days, storage = localStorage, now = Date.now()) {
+  const history = getHistory(storage);
+  const cutoffDate = new Date(now - days * 24 * 60 * 60 * 1000);
+  const cutoffStr = cutoffDate.toISOString().split('T')[0];
+
+  return history.filter(session => session.date >= cutoffStr);
+}
+
+/**
+ * 히스토리 초기화 (테스트용)
+ * @param {Storage} storage
+ */
+export function resetHistory(storage = localStorage) {
+  storage.removeItem(STORAGE_KEY);
+}

--- a/src/utils/sleep.js
+++ b/src/utils/sleep.js
@@ -1,0 +1,63 @@
+/**
+ * 수면 데이터 관리 함수
+ */
+
+import { getToday } from './date.js';
+
+const STORAGE_KEY = 'tongueSleep';
+
+/**
+ * 오늘 수면 데이터 조회
+ * @param {Storage} storage - localStorage 또는 mock
+ * @param {number} now - 현재 타임스탬프
+ * @returns {Object|null} { hours, quality } 또는 null
+ */
+export function getTodaySleep(storage = localStorage, now = Date.now()) {
+  const data = JSON.parse(storage.getItem(STORAGE_KEY) || '{}');
+  const today = getToday(now);
+  return data[today] || null;
+}
+
+/**
+ * 특정 날짜의 수면 데이터 조회
+ * @param {string} date - YYYY-MM-DD 형식
+ * @param {Storage} storage
+ * @returns {Object|null}
+ */
+export function getSleepByDate(date, storage = localStorage) {
+  const data = JSON.parse(storage.getItem(STORAGE_KEY) || '{}');
+  return data[date] || null;
+}
+
+/**
+ * 수면 데이터 저장
+ * @param {number|string} hours - 수면 시간
+ * @param {string} quality - 'great' | 'good' | 'bad'
+ * @param {Storage} storage
+ * @param {number} now
+ * @returns {Object} 저장된 수면 데이터
+ */
+export function saveSleep(hours, quality, storage = localStorage, now = Date.now()) {
+  const data = JSON.parse(storage.getItem(STORAGE_KEY) || '{}');
+  const today = getToday(now);
+  data[today] = { hours, quality };
+  storage.setItem(STORAGE_KEY, JSON.stringify(data));
+  return data[today];
+}
+
+/**
+ * 모든 수면 데이터 조회
+ * @param {Storage} storage
+ * @returns {Object} { [date]: { hours, quality } }
+ */
+export function getAllSleepData(storage = localStorage) {
+  return JSON.parse(storage.getItem(STORAGE_KEY) || '{}');
+}
+
+/**
+ * 수면 데이터 초기화 (테스트용)
+ * @param {Storage} storage
+ */
+export function resetSleepData(storage = localStorage) {
+  storage.removeItem(STORAGE_KEY);
+}

--- a/src/utils/streak.js
+++ b/src/utils/streak.js
@@ -1,0 +1,70 @@
+/**
+ * 연속일(Streak) 관리 함수
+ * 의존성 주입으로 테스트 가능
+ */
+
+import { getTodayString, getYesterdayString } from './date.js';
+
+const STORAGE_KEY = 'tongueTraining';
+
+/**
+ * 현재 연속일 로드
+ * - 오늘 또는 어제 훈련한 경우: 저장된 streak 반환
+ * - 그 외: 0 반환 (연속 끊김)
+ *
+ * @param {Storage} storage - localStorage 또는 mock
+ * @param {number} now - 현재 타임스탬프
+ * @returns {number} 연속일 수
+ */
+export function loadStreak(storage = localStorage, now = Date.now()) {
+  const data = JSON.parse(storage.getItem(STORAGE_KEY) || '{}');
+  const today = getTodayString(now);
+  const yesterday = getYesterdayString(now);
+
+  if (data.lastDate === today || data.lastDate === yesterday) {
+    return data.streak || 1;
+  }
+  return 0;
+}
+
+/**
+ * 연속일 저장 (훈련 완료 시 호출)
+ * - 어제 훈련: streak + 1
+ * - 오늘 이미 훈련: streak 유지
+ * - 그 외: streak = 1 (새로 시작)
+ *
+ * @param {Storage} storage - localStorage 또는 mock
+ * @param {number} now - 현재 타임스탬프
+ * @returns {number} 새로운 연속일 수
+ */
+export function saveStreak(storage = localStorage, now = Date.now()) {
+  const data = JSON.parse(storage.getItem(STORAGE_KEY) || '{}');
+  const today = getTodayString(now);
+  const yesterday = getYesterdayString(now);
+
+  let newStreak = 1;
+
+  if (data.lastDate === yesterday) {
+    // 어제 훈련 → 연속 이어감
+    newStreak = (data.streak || 0) + 1;
+  } else if (data.lastDate === today) {
+    // 오늘 이미 훈련 → 유지
+    newStreak = data.streak || 1;
+  }
+  // 그 외 → 새로 시작 (newStreak = 1)
+
+  storage.setItem(STORAGE_KEY, JSON.stringify({
+    lastDate: today,
+    streak: newStreak
+  }));
+
+  return newStreak;
+}
+
+/**
+ * 연속일 데이터 초기화 (테스트용)
+ * @param {Storage} storage
+ */
+export function resetStreak(storage = localStorage) {
+  storage.removeItem(STORAGE_KEY);
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,302 @@
+/**
+ * 혀 훈련 PWA - Service Worker
+ * 오프라인 지원 및 캐싱 전략
+ */
+
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `tt-static-${CACHE_VERSION}`;
+const DYNAMIC_CACHE = `tt-dynamic-${CACHE_VERSION}`;
+
+// 정적 리소스 - Cache First
+const STATIC_ASSETS = [
+  '/',
+  '/tongue-training.html',
+  '/manifest.json',
+  '/icons/icon.svg'
+];
+
+// 외부 리소스 - Stale While Revalidate
+const EXTERNAL_PATTERNS = [
+  'fonts.googleapis.com',
+  'fonts.gstatic.com',
+  'unpkg.com/@splinetool'
+];
+
+// 설치 이벤트 - 정적 리소스 캐싱
+self.addEventListener('install', (event) => {
+  console.log('[SW] Installing...');
+
+  event.waitUntil(
+    caches.open(STATIC_CACHE)
+      .then((cache) => {
+        console.log('[SW] Caching static assets');
+        return cache.addAll(STATIC_ASSETS);
+      })
+      .then(() => {
+        console.log('[SW] Installation complete');
+        return self.skipWaiting();
+      })
+      .catch((error) => {
+        console.error('[SW] Installation failed:', error);
+      })
+  );
+});
+
+// 활성화 이벤트 - 이전 캐시 정리
+self.addEventListener('activate', (event) => {
+  console.log('[SW] Activating...');
+
+  event.waitUntil(
+    caches.keys()
+      .then((cacheNames) => {
+        return Promise.all(
+          cacheNames
+            .filter((name) => {
+              return name.startsWith('tt-') &&
+                     name !== STATIC_CACHE &&
+                     name !== DYNAMIC_CACHE;
+            })
+            .map((name) => {
+              console.log('[SW] Deleting old cache:', name);
+              return caches.delete(name);
+            })
+        );
+      })
+      .then(() => {
+        console.log('[SW] Activation complete');
+        return self.clients.claim();
+      })
+  );
+});
+
+// Fetch 이벤트 - 캐싱 전략
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Chrome extension 등 제외
+  if (!url.protocol.startsWith('http')) {
+    return;
+  }
+
+  // 외부 리소스 - Stale While Revalidate
+  if (isExternalResource(url.href)) {
+    event.respondWith(staleWhileRevalidate(request));
+    return;
+  }
+
+  // 정적 리소스 - Cache First
+  if (isStaticAsset(url.pathname)) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  // 기타 - Network First with Cache Fallback
+  event.respondWith(networkFirst(request));
+});
+
+/**
+ * Cache First 전략
+ * 캐시에 있으면 캐시 반환, 없으면 네트워크 요청 후 캐싱
+ */
+async function cacheFirst(request) {
+  const cachedResponse = await caches.match(request);
+
+  if (cachedResponse) {
+    return cachedResponse;
+  }
+
+  try {
+    const networkResponse = await fetch(request);
+
+    if (networkResponse.ok) {
+      const cache = await caches.open(STATIC_CACHE);
+      cache.put(request, networkResponse.clone());
+    }
+
+    return networkResponse;
+  } catch (error) {
+    console.error('[SW] Cache First failed:', error);
+    return createOfflineResponse();
+  }
+}
+
+/**
+ * Network First 전략
+ * 네트워크 우선, 실패 시 캐시 폴백
+ */
+async function networkFirst(request) {
+  try {
+    const networkResponse = await fetch(request);
+
+    if (networkResponse.ok) {
+      const cache = await caches.open(DYNAMIC_CACHE);
+      cache.put(request, networkResponse.clone());
+    }
+
+    return networkResponse;
+  } catch (error) {
+    const cachedResponse = await caches.match(request);
+
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    return createOfflineResponse();
+  }
+}
+
+/**
+ * Stale While Revalidate 전략
+ * 캐시 즉시 반환, 백그라운드에서 업데이트
+ */
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(DYNAMIC_CACHE);
+  const cachedResponse = await cache.match(request);
+
+  const fetchPromise = fetch(request)
+    .then((networkResponse) => {
+      if (networkResponse.ok) {
+        cache.put(request, networkResponse.clone());
+      }
+      return networkResponse;
+    })
+    .catch(() => cachedResponse);
+
+  return cachedResponse || fetchPromise;
+}
+
+/**
+ * 정적 리소스 확인
+ */
+function isStaticAsset(pathname) {
+  return STATIC_ASSETS.includes(pathname) ||
+         pathname.endsWith('.html') ||
+         pathname.endsWith('.css') ||
+         pathname.endsWith('.js') ||
+         pathname.endsWith('.svg') ||
+         pathname.endsWith('.png') ||
+         pathname.endsWith('.ico');
+}
+
+/**
+ * 외부 리소스 확인
+ */
+function isExternalResource(url) {
+  return EXTERNAL_PATTERNS.some(pattern => url.includes(pattern));
+}
+
+/**
+ * 오프라인 응답 생성
+ */
+function createOfflineResponse() {
+  const html = `
+    <!DOCTYPE html>
+    <html lang="ko">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>오프라인 - 혀 훈련</title>
+      <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+          background: linear-gradient(135deg, #0a0a0f 0%, #1a1a2e 100%);
+          color: #fff;
+          min-height: 100vh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          text-align: center;
+          padding: 20px;
+        }
+        .offline-container {
+          max-width: 400px;
+        }
+        .offline-icon {
+          font-size: 64px;
+          margin-bottom: 24px;
+        }
+        h1 {
+          font-size: 24px;
+          margin-bottom: 12px;
+        }
+        p {
+          color: rgba(255,255,255,0.6);
+          margin-bottom: 24px;
+          line-height: 1.6;
+        }
+        button {
+          background: linear-gradient(135deg, #6366f1, #8b5cf6);
+          color: #fff;
+          border: none;
+          padding: 12px 24px;
+          border-radius: 12px;
+          font-size: 16px;
+          cursor: pointer;
+          transition: transform 0.2s;
+        }
+        button:active {
+          transform: scale(0.95);
+        }
+      </style>
+    </head>
+    <body>
+      <div class="offline-container">
+        <div class="offline-icon">📶</div>
+        <h1>오프라인 상태입니다</h1>
+        <p>인터넷 연결을 확인해주세요.<br>연결되면 자동으로 다시 시도합니다.</p>
+        <button onclick="location.reload()">다시 시도</button>
+      </div>
+      <script>
+        window.addEventListener('online', () => location.reload());
+      </script>
+    </body>
+    </html>
+  `;
+
+  return new Response(html, {
+    status: 503,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8'
+    }
+  });
+}
+
+// 백그라운드 동기화 이벤트 (향후 Phase 5)
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'sync-sessions') {
+    console.log('[SW] Background sync triggered');
+    // 향후 서버 동기화 구현
+  }
+});
+
+// 푸시 알림 이벤트 (향후 확장)
+self.addEventListener('push', (event) => {
+  const data = event.data?.json() || {};
+
+  const options = {
+    body: data.body || '훈련 시간이에요!',
+    icon: '/icons/icon.svg',
+    badge: '/icons/icon.svg',
+    vibrate: [100, 50, 100],
+    data: {
+      url: data.url || '/tongue-training.html'
+    }
+  };
+
+  event.waitUntil(
+    self.registration.showNotification(data.title || '혀 훈련', options)
+  );
+});
+
+// 알림 클릭 이벤트
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  event.waitUntil(
+    clients.openWindow(event.notification.data.url)
+  );
+});
+
+console.log('[SW] Service Worker loaded');

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,65 @@
+/**
+ * Vitest 테스트 설정
+ * - localStorage 모킹
+ * - Date 모킹 헬퍼
+ */
+
+import { vi, beforeEach, afterEach } from 'vitest';
+
+// localStorage 모킹
+function createLocalStorageMock() {
+  let store = {};
+  return {
+    getItem: vi.fn((key) => store[key] ?? null),
+    setItem: vi.fn((key, value) => { store[key] = String(value); }),
+    removeItem: vi.fn((key) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((i) => Object.keys(store)[i] ?? null),
+    // 테스트용 헬퍼
+    _getStore: () => store,
+    _setStore: (newStore) => { store = newStore; }
+  };
+}
+
+const localStorageMock = createLocalStorageMock();
+
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+  writable: true
+});
+
+// Date 모킹 헬퍼
+export function mockDate(dateString) {
+  const fixedDate = new Date(dateString);
+  vi.useFakeTimers();
+  vi.setSystemTime(fixedDate);
+  return fixedDate;
+}
+
+export function resetDate() {
+  vi.useRealTimers();
+}
+
+// 테스트용 localStorage 헬퍼
+export function createMockStorage(initialData = {}) {
+  const store = { ...initialData };
+  return {
+    getItem: vi.fn((key) => store[key] ?? null),
+    setItem: vi.fn((key, value) => { store[key] = String(value); }),
+    removeItem: vi.fn((key) => { delete store[key]; }),
+    clear: vi.fn(() => { Object.keys(store).forEach(k => delete store[k]); }),
+    _getStore: () => store
+  };
+}
+
+// 각 테스트 전 초기화
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+// 각 테스트 후 정리
+afterEach(() => {
+  vi.useRealTimers();
+});

--- a/tests/unit/badges.test.js
+++ b/tests/unit/badges.test.js
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  BADGES,
+  getBadgeById,
+  getEarnedBadges,
+  getNewBadges,
+  calculateBadgeStats,
+  loadProfile,
+  saveProfile,
+  updateBadges
+} from '../../src/gamification/badges.js';
+import { createMockStorage } from '../setup.js';
+
+describe('badges', () => {
+  describe('BADGES', () => {
+    it('8개의 배지가 정의되어야 한다', () => {
+      expect(BADGES).toHaveLength(8);
+    });
+
+    it('각 배지는 id, emoji, name, description을 가져야 한다', () => {
+      BADGES.forEach(badge => {
+        expect(badge).toHaveProperty('id');
+        expect(badge).toHaveProperty('emoji');
+        expect(badge).toHaveProperty('name');
+        expect(badge).toHaveProperty('description');
+      });
+    });
+  });
+
+  describe('getBadgeById', () => {
+    it('존재하는 배지 ID로 배지 정보를 반환해야 한다', () => {
+      const badge = getBadgeById('first_step');
+      expect(badge).not.toBeNull();
+      expect(badge.emoji).toBe('🌱');
+      expect(badge.name).toBe('첫 걸음');
+    });
+
+    it('존재하지 않는 배지 ID는 null을 반환해야 한다', () => {
+      expect(getBadgeById('nonexistent')).toBeNull();
+    });
+  });
+
+  describe('getEarnedBadges', () => {
+    it('첫 세션 완료 시 first_step 배지를 획득해야 한다', () => {
+      const stats = { totalSessions: 1, maxStreak: 1 };
+      expect(getEarnedBadges(stats)).toContain('first_step');
+    });
+
+    it('7일 연속 시 week_warrior 배지를 획득해야 한다', () => {
+      const stats = { totalSessions: 7, maxStreak: 7 };
+      const badges = getEarnedBadges(stats);
+      expect(badges).toContain('first_step');
+      expect(badges).toContain('week_warrior');
+    });
+
+    it('30일 연속 시 month_miracle 배지를 획득해야 한다', () => {
+      const stats = { totalSessions: 30, maxStreak: 30 };
+      expect(getEarnedBadges(stats)).toContain('month_miracle');
+    });
+
+    it('아침 10회 훈련 시 morning_bird 배지를 획득해야 한다', () => {
+      const stats = { totalSessions: 10, morningCount: 10 };
+      expect(getEarnedBadges(stats)).toContain('morning_bird');
+    });
+
+    it('저녁 10회 훈련 시 night_owl 배지를 획득해야 한다', () => {
+      const stats = { totalSessions: 10, eveningCount: 10 };
+      expect(getEarnedBadges(stats)).toContain('night_owl');
+    });
+
+    it('좋은 수면 후 10회 훈련 시 sleep_master 배지를 획득해야 한다', () => {
+      const stats = { totalSessions: 10, goodSleepCount: 10 };
+      expect(getEarnedBadges(stats)).toContain('sleep_master');
+    });
+
+    it('100회 훈련 시 century 배지를 획득해야 한다', () => {
+      const stats = { totalSessions: 100 };
+      expect(getEarnedBadges(stats)).toContain('century');
+    });
+
+    it('8주 프로그램 완주 시 champion 배지를 획득해야 한다', () => {
+      const stats = { totalSessions: 56, programWeeks: 8 };
+      expect(getEarnedBadges(stats)).toContain('champion');
+    });
+  });
+
+  describe('getNewBadges', () => {
+    it('새로 획득한 배지만 반환해야 한다', () => {
+      const current = ['first_step'];
+      const earned = ['first_step', 'week_warrior'];
+      expect(getNewBadges(current, earned)).toEqual(['week_warrior']);
+    });
+
+    it('이미 모든 배지를 가지고 있으면 빈 배열을 반환해야 한다', () => {
+      const current = ['first_step', 'week_warrior'];
+      const earned = ['first_step', 'week_warrior'];
+      expect(getNewBadges(current, earned)).toEqual([]);
+    });
+  });
+
+  describe('calculateBadgeStats', () => {
+    it('빈 히스토리는 모든 값이 0이어야 한다', () => {
+      const stats = calculateBadgeStats([], {}, 0);
+      expect(stats.totalSessions).toBe(0);
+      expect(stats.morningCount).toBe(0);
+      expect(stats.eveningCount).toBe(0);
+      expect(stats.goodSleepCount).toBe(0);
+      expect(stats.programWeeks).toBe(0);
+    });
+
+    it('아침 훈련 (6-9시)을 정확히 카운트해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', timestamp: new Date('2026-03-10T07:00:00').getTime() },
+        { date: '2026-03-11', timestamp: new Date('2026-03-11T08:30:00').getTime() },
+        { date: '2026-03-12', timestamp: new Date('2026-03-12T10:00:00').getTime() } // 아침 아님
+      ];
+      const stats = calculateBadgeStats(history, {}, 3);
+      expect(stats.morningCount).toBe(2);
+    });
+
+    it('저녁 훈련 (21시 이후)을 정확히 카운트해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', timestamp: new Date('2026-03-10T21:30:00').getTime() },
+        { date: '2026-03-11', timestamp: new Date('2026-03-11T23:00:00').getTime() },
+        { date: '2026-03-12', timestamp: new Date('2026-03-12T02:00:00').getTime() } // 새벽도 포함
+      ];
+      const stats = calculateBadgeStats(history, {}, 3);
+      expect(stats.eveningCount).toBe(3);
+    });
+
+    it('7시간+ 수면 후 훈련을 정확히 카운트해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', timestamp: Date.now() },
+        { date: '2026-03-11', timestamp: Date.now() }
+      ];
+      const sleepData = {
+        '2026-03-10': { hours: 8 },
+        '2026-03-11': { hours: 5 }
+      };
+      const stats = calculateBadgeStats(history, sleepData, 2);
+      expect(stats.goodSleepCount).toBe(1);
+    });
+
+    it('프로그램 주차를 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-01', timestamp: Date.now() },
+        { date: '2026-03-15', timestamp: Date.now() } // 2주 후
+      ];
+      const stats = calculateBadgeStats(history, {}, 2);
+      expect(stats.programWeeks).toBe(3); // 1일차 = 1주, 15일차 = 3주
+    });
+  });
+
+  describe('loadProfile / saveProfile', () => {
+    it('저장된 프로필이 없으면 기본값을 반환해야 한다', () => {
+      const storage = createMockStorage();
+      const profile = loadProfile(storage);
+      expect(profile).toEqual({
+        xp: 0,
+        level: 1,
+        badges: [],
+        badgeNotified: []
+      });
+    });
+
+    it('프로필을 저장하고 로드할 수 있어야 한다', () => {
+      const storage = createMockStorage();
+      const profile = { xp: 100, level: 2, badges: ['first_step'], badgeNotified: [] };
+      saveProfile(profile, storage);
+
+      expect(storage.setItem).toHaveBeenCalledWith('tongueProfile', JSON.stringify(profile));
+    });
+  });
+
+  describe('updateBadges', () => {
+    it('새 배지 획득 시 프로필을 업데이트해야 한다', () => {
+      const storage = createMockStorage();
+      const stats = { totalSessions: 1, maxStreak: 1 };
+
+      const result = updateBadges(stats, storage);
+
+      expect(result.newBadges).toContain('first_step');
+      expect(result.profile.badges).toContain('first_step');
+      expect(storage.setItem).toHaveBeenCalled();
+    });
+
+    it('새 배지가 없으면 프로필을 업데이트하지 않아야 한다', () => {
+      const storage = createMockStorage({
+        tongueProfile: JSON.stringify({
+          xp: 50, level: 1, badges: ['first_step'], badgeNotified: ['first_step']
+        })
+      });
+      const stats = { totalSessions: 1, maxStreak: 1 };
+
+      const result = updateBadges(stats, storage);
+
+      expect(result.newBadges).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/calculations.test.js
+++ b/tests/unit/calculations.test.js
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateStats,
+  calculateMaxStreak,
+  calculateHeatmapData,
+  calculateWeeklyData,
+  calculateSleepInsight,
+  calculateBestTrainingTime,
+  calculateCorrelationData
+} from '../../src/stats/calculations.js';
+
+describe('calculations', () => {
+  describe('calculateStats', () => {
+    it('빈 히스토리에 대해 모든 값이 0이어야 한다', () => {
+      expect(calculateStats([])).toEqual({
+        uniqueDays: 0,
+        totalReps: 0,
+        totalMinutes: 0,
+        maxStreak: 0
+      });
+    });
+
+    it('null 히스토리에 대해 모든 값이 0이어야 한다', () => {
+      expect(calculateStats(null)).toEqual({
+        uniqueDays: 0,
+        totalReps: 0,
+        totalMinutes: 0,
+        maxStreak: 0
+      });
+    });
+
+    it('고유 날짜 수를 정확히 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', duration: 120, reps: 35 },
+        { date: '2026-03-10', duration: 60, reps: 20 }, // 같은 날 두 번
+        { date: '2026-03-11', duration: 130, reps: 35 }
+      ];
+      expect(calculateStats(history).uniqueDays).toBe(2);
+    });
+
+    it('총 반복 횟수를 정확히 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', reps: 35 },
+        { date: '2026-03-11', reps: 30 },
+        { date: '2026-03-12', reps: 25 }
+      ];
+      expect(calculateStats(history).totalReps).toBe(90);
+    });
+
+    it('총 시간을 분 단위로 정확히 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', duration: 120 }, // 2분
+        { date: '2026-03-11', duration: 180 }  // 3분
+      ];
+      expect(calculateStats(history).totalMinutes).toBe(5);
+    });
+  });
+
+  describe('calculateMaxStreak', () => {
+    it('빈 히스토리면 0을 반환해야 한다', () => {
+      expect(calculateMaxStreak([])).toBe(0);
+    });
+
+    it('단일 날짜면 1을 반환해야 한다', () => {
+      const history = [{ date: '2026-03-10' }];
+      expect(calculateMaxStreak(history)).toBe(1);
+    });
+
+    it('연속 3일 훈련을 정확히 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-09' },
+        { date: '2026-03-10' },
+        { date: '2026-03-11' }
+      ];
+      expect(calculateMaxStreak(history)).toBe(3);
+    });
+
+    it('5일 연속 후 2일 연속이면 최장 5일을 반환해야 한다', () => {
+      const history = [
+        { date: '2026-03-01' },
+        { date: '2026-03-02' },
+        { date: '2026-03-03' },
+        { date: '2026-03-04' },
+        { date: '2026-03-05' },
+        // 하루 건너뜀
+        { date: '2026-03-10' },
+        { date: '2026-03-11' }
+      ];
+      expect(calculateMaxStreak(history)).toBe(5);
+    });
+
+    it('같은 날 여러 세션은 하나로 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-10' },
+        { date: '2026-03-10' },
+        { date: '2026-03-11' }
+      ];
+      expect(calculateMaxStreak(history)).toBe(2);
+    });
+  });
+
+  describe('calculateHeatmapData', () => {
+    it('빈 히스토리면 빈 객체를 반환해야 한다', () => {
+      expect(calculateHeatmapData([])).toEqual({});
+    });
+
+    it('날짜별 세션 수를 정확히 집계해야 한다', () => {
+      const history = [
+        { date: '2026-03-10' },
+        { date: '2026-03-10' },
+        { date: '2026-03-11' }
+      ];
+      expect(calculateHeatmapData(history)).toEqual({
+        '2026-03-10': 2,
+        '2026-03-11': 1
+      });
+    });
+  });
+
+  describe('calculateWeeklyData', () => {
+    // 2026-03-11 (수요일)
+    const fixedNow = new Date('2026-03-11T10:00:00Z').getTime();
+
+    it('주간 7일 데이터를 반환해야 한다', () => {
+      const { weekData } = calculateWeeklyData([], fixedNow);
+      expect(weekData).toHaveLength(7);
+    });
+
+    it('요일을 올바르게 표시해야 한다', () => {
+      const { weekData } = calculateWeeklyData([], fixedNow);
+      expect(weekData.map(d => d.day)).toEqual(['월', '화', '수', '목', '금', '토', '일']);
+    });
+
+    it('오늘을 표시해야 한다', () => {
+      const { weekData } = calculateWeeklyData([], fixedNow);
+      const today = weekData.find(d => d.isToday);
+      expect(today).toBeDefined();
+      expect(today.date).toBe('2026-03-11');
+    });
+
+    it('해당 주의 훈련 시간을 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-09', duration: 120 }, // 월요일
+        { date: '2026-03-10', duration: 180 }, // 화요일
+        { date: '2026-03-01', duration: 300 }  // 지난주 (포함 안 됨)
+      ];
+      const { weekData } = calculateWeeklyData(history, fixedNow);
+
+      expect(weekData.find(d => d.date === '2026-03-09').minutes).toBe(2);
+      expect(weekData.find(d => d.date === '2026-03-10').minutes).toBe(3);
+    });
+  });
+
+  describe('calculateSleepInsight', () => {
+    it('수면 데이터가 3일 미만이면 hasEnoughData가 false여야 한다', () => {
+      const history = [{ date: '2026-03-10', reps: 35 }];
+      const sleepData = { '2026-03-10': { hours: 7, quality: 'good' } };
+
+      expect(calculateSleepInsight(history, sleepData).hasEnoughData).toBe(false);
+    });
+
+    it('7시간 이상/미만 수면 완주율을 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-08', reps: 35 },
+        { date: '2026-03-09', reps: 35 },
+        { date: '2026-03-10', reps: 20 },
+        { date: '2026-03-11', reps: 35 }
+      ];
+      const sleepData = {
+        '2026-03-08': { hours: 8 },   // 좋은 수면, 완주
+        '2026-03-09': { hours: 7 },   // 좋은 수면, 완주
+        '2026-03-10': { hours: 5 },   // 나쁜 수면, 미완주
+        '2026-03-11': { hours: 6 }    // 나쁜 수면, 완주
+      };
+
+      const result = calculateSleepInsight(history, sleepData, 35);
+      expect(result.hasEnoughData).toBe(true);
+      expect(result.goodRate).toBe(100);  // 2/2 = 100%
+      expect(result.badRate).toBe(50);    // 1/2 = 50%
+      expect(result.diff).toBe(50);
+    });
+  });
+
+  describe('calculateBestTrainingTime', () => {
+    it('시간대별 완주율을 계산해야 한다', () => {
+      const history = [
+        { timestamp: new Date('2026-03-10T08:00:00').getTime(), reps: 35 }, // 아침, 완주
+        { timestamp: new Date('2026-03-10T09:00:00').getTime(), reps: 35 }, // 아침, 완주
+        { timestamp: new Date('2026-03-11T14:00:00').getTime(), reps: 20 }, // 오후, 미완주
+        { timestamp: new Date('2026-03-11T20:00:00').getTime(), reps: 35 }  // 저녁, 완주
+      ];
+
+      const result = calculateBestTrainingTime(history, 35);
+      expect(result.bestTime).toBe('morning');
+      expect(result.bestRate).toBe(100);
+      expect(result.rates.morning.rate).toBe(1);
+      expect(result.rates.afternoon.rate).toBe(0);
+      expect(result.rates.evening.rate).toBe(1);
+    });
+
+    it('최적 시간대 레이블을 반환해야 한다', () => {
+      const history = [
+        { timestamp: new Date('2026-03-10T08:00:00').getTime(), reps: 35 }
+      ];
+
+      const result = calculateBestTrainingTime(history, 35);
+      expect(result.bestTimeLabel).toBe('아침 (5-12시)');
+    });
+  });
+
+  describe('calculateCorrelationData', () => {
+    it('수면 데이터가 있는 세션만 반환해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', duration: 120, reps: 35 },
+        { date: '2026-03-11', duration: 130, reps: 35 }
+      ];
+      const sleepData = {
+        '2026-03-10': { hours: 7 }
+        // '2026-03-11' 없음
+      };
+
+      const result = calculateCorrelationData(history, sleepData, 35);
+      expect(result).toHaveLength(1);
+      expect(result[0].date).toBe('2026-03-10');
+    });
+
+    it('좌표를 올바르게 계산해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', duration: 420, reps: 35 } // 7분 정확히
+      ];
+      const sleepData = {
+        '2026-03-10': { hours: 7 } // (7-4)/6 = 0.5
+      };
+
+      const result = calculateCorrelationData(history, sleepData, 35);
+      expect(result[0].x).toBe(0.5);    // 7시간 수면 -> (7-4)/6 = 0.5
+      expect(result[0].y).toBeCloseTo(0.467, 2);  // 7분/15분 ≈ 0.467
+      expect(result[0].completed).toBe(true);
+    });
+
+    it('좌표를 0-1 범위로 제한해야 한다', () => {
+      const history = [
+        { date: '2026-03-10', duration: 1200, reps: 35 } // 20분
+      ];
+      const sleepData = {
+        '2026-03-10': { hours: 12 } // 범위 초과
+      };
+
+      const result = calculateCorrelationData(history, sleepData, 35);
+      expect(result[0].x).toBe(1);  // 최대값 제한
+      expect(result[0].y).toBe(1);  // 최대값 제한
+    });
+  });
+});

--- a/tests/unit/date.test.js
+++ b/tests/unit/date.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { getToday, getTodayString, getYesterdayString, getDaysDiff, isConsecutive } from '../../src/utils/date.js';
+
+describe('date utils', () => {
+  // 고정된 날짜: 2026-03-11 10:00:00 UTC
+  const fixedNow = new Date('2026-03-11T10:00:00Z').getTime();
+
+  describe('getToday', () => {
+    it('ISO 형식 날짜를 반환해야 한다', () => {
+      expect(getToday(fixedNow)).toBe('2026-03-11');
+    });
+
+    it('기본값으로 현재 날짜를 사용해야 한다', () => {
+      const today = getToday();
+      expect(today).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('getTodayString', () => {
+    it('Date.toDateString 형식을 반환해야 한다', () => {
+      const result = getTodayString(fixedNow);
+      expect(result).toBe('Wed Mar 11 2026');
+    });
+  });
+
+  describe('getYesterdayString', () => {
+    it('어제 날짜를 반환해야 한다', () => {
+      const result = getYesterdayString(fixedNow);
+      expect(result).toBe('Tue Mar 10 2026');
+    });
+  });
+
+  describe('getDaysDiff', () => {
+    it('같은 날짜면 0을 반환해야 한다', () => {
+      expect(getDaysDiff('2026-03-11', '2026-03-11')).toBe(0);
+    });
+
+    it('하루 차이면 1을 반환해야 한다', () => {
+      expect(getDaysDiff('2026-03-10', '2026-03-11')).toBe(1);
+    });
+
+    it('일주일 차이면 7을 반환해야 한다', () => {
+      expect(getDaysDiff('2026-03-04', '2026-03-11')).toBe(7);
+    });
+
+    it('순서가 바뀌어도 절대값을 반환해야 한다', () => {
+      expect(getDaysDiff('2026-03-11', '2026-03-04')).toBe(7);
+    });
+  });
+
+  describe('isConsecutive', () => {
+    it('연속된 날짜면 true를 반환해야 한다', () => {
+      expect(isConsecutive('2026-03-10', '2026-03-11')).toBe(true);
+    });
+
+    it('같은 날짜면 false를 반환해야 한다', () => {
+      expect(isConsecutive('2026-03-11', '2026-03-11')).toBe(false);
+    });
+
+    it('2일 이상 차이면 false를 반환해야 한다', () => {
+      expect(isConsecutive('2026-03-09', '2026-03-11')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/history.test.js
+++ b/tests/unit/history.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getHistory, saveSession, getSessionsByDate, getRecentSessions, resetHistory } from '../../src/utils/history.js';
+import { createMockStorage } from '../setup.js';
+
+describe('history', () => {
+  const fixedNow = new Date('2026-03-11T10:00:00Z').getTime();
+  const today = '2026-03-11';
+  const yesterday = '2026-03-10';
+
+  describe('getHistory', () => {
+    it('데이터가 없으면 빈 배열을 반환해야 한다', () => {
+      const storage = createMockStorage();
+      expect(getHistory(storage)).toEqual([]);
+    });
+
+    it('저장된 히스토리를 반환해야 한다', () => {
+      const history = [
+        { date: yesterday, duration: 120, reps: 35 },
+        { date: today, duration: 130, reps: 35 }
+      ];
+      const storage = createMockStorage({
+        tongueHistory: JSON.stringify(history)
+      });
+
+      expect(getHistory(storage)).toEqual(history);
+    });
+  });
+
+  describe('saveSession', () => {
+    it('새 세션을 히스토리에 추가해야 한다', () => {
+      const storage = createMockStorage();
+      const session = saveSession(120, 35, storage, fixedNow);
+
+      expect(session.date).toBe(today);
+      expect(session.timestamp).toBe(fixedNow);
+      expect(session.duration).toBe(120);
+      expect(session.reps).toBe(35);
+    });
+
+    it('기존 히스토리에 세션을 추가해야 한다', () => {
+      const existing = [{ date: yesterday, duration: 100, reps: 30 }];
+      const storage = createMockStorage({
+        tongueHistory: JSON.stringify(existing)
+      });
+
+      saveSession(120, 35, storage, fixedNow);
+
+      const savedData = JSON.parse(storage.setItem.mock.calls[0][1]);
+      expect(savedData).toHaveLength(2);
+      expect(savedData[0].date).toBe(yesterday);
+      expect(savedData[1].date).toBe(today);
+    });
+
+    it('오늘 수면 데이터를 포함해야 한다', () => {
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify({
+          [today]: { hours: 7, quality: 'good' }
+        })
+      });
+
+      const session = saveSession(120, 35, storage, fixedNow);
+
+      expect(session.sleep).toEqual({ hours: 7, quality: 'good' });
+    });
+
+    it('수면 데이터가 없으면 null이어야 한다', () => {
+      const storage = createMockStorage();
+      const session = saveSession(120, 35, storage, fixedNow);
+
+      expect(session.sleep).toBeNull();
+    });
+  });
+
+  describe('getSessionsByDate', () => {
+    it('특정 날짜의 세션만 반환해야 한다', () => {
+      const history = [
+        { date: yesterday, duration: 100, reps: 30 },
+        { date: today, duration: 120, reps: 35 },
+        { date: today, duration: 60, reps: 20 }
+      ];
+      const storage = createMockStorage({
+        tongueHistory: JSON.stringify(history)
+      });
+
+      const sessions = getSessionsByDate(today, storage);
+      expect(sessions).toHaveLength(2);
+      expect(sessions.every(s => s.date === today)).toBe(true);
+    });
+
+    it('세션이 없는 날짜면 빈 배열을 반환해야 한다', () => {
+      const storage = createMockStorage({
+        tongueHistory: JSON.stringify([{ date: today, duration: 120, reps: 35 }])
+      });
+
+      expect(getSessionsByDate('2026-03-01', storage)).toEqual([]);
+    });
+  });
+
+  describe('getRecentSessions', () => {
+    it('최근 N일간의 세션을 반환해야 한다', () => {
+      const history = [
+        { date: '2026-03-01', duration: 100, reps: 30 },
+        { date: '2026-03-05', duration: 110, reps: 32 },
+        { date: yesterday, duration: 120, reps: 35 },
+        { date: today, duration: 130, reps: 35 }
+      ];
+      const storage = createMockStorage({
+        tongueHistory: JSON.stringify(history)
+      });
+
+      // 최근 7일
+      const recent = getRecentSessions(7, storage, fixedNow);
+      expect(recent).toHaveLength(3); // 03-05, 03-10, 03-11
+      expect(recent.every(s => s.date >= '2026-03-04')).toBe(true);
+    });
+
+    it('최근 2일이면 오늘과 어제를 반환해야 한다', () => {
+      const history = [
+        { date: '2026-03-08', duration: 100, reps: 30 },
+        { date: yesterday, duration: 120, reps: 35 },
+        { date: today, duration: 130, reps: 35 }
+      ];
+      const storage = createMockStorage({
+        tongueHistory: JSON.stringify(history)
+      });
+
+      const recent = getRecentSessions(2, storage, fixedNow);
+      expect(recent).toHaveLength(2);
+      expect(recent.map(s => s.date)).toContain(today);
+      expect(recent.map(s => s.date)).toContain(yesterday);
+    });
+  });
+
+  describe('resetHistory', () => {
+    it('히스토리를 삭제해야 한다', () => {
+      const storage = createMockStorage({
+        tongueHistory: JSON.stringify([{ date: today, duration: 120, reps: 35 }])
+      });
+      resetHistory(storage);
+
+      expect(storage.removeItem).toHaveBeenCalledWith('tongueHistory');
+    });
+  });
+});

--- a/tests/unit/level.test.js
+++ b/tests/unit/level.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  XP_VALUES,
+  LEVEL_THRESHOLDS,
+  calculateLevel,
+  calculateSessionXp,
+  addXp,
+  getLevelInfo
+} from '../../src/gamification/level.js';
+
+describe('level', () => {
+  describe('XP_VALUES', () => {
+    it('올바른 XP 값이 정의되어야 한다', () => {
+      expect(XP_VALUES.SESSION_COMPLETE).toBe(50);
+      expect(XP_VALUES.FULL_COMPLETE_BONUS).toBe(20);
+      expect(XP_VALUES.STREAK_MULTIPLIER).toBe(5);
+      expect(XP_VALUES.BADGE_EARNED).toBe(100);
+    });
+  });
+
+  describe('LEVEL_THRESHOLDS', () => {
+    it('21개 레벨이 정의되어야 한다', () => {
+      expect(LEVEL_THRESHOLDS.length).toBe(21);
+    });
+
+    it('레벨 1은 0 XP로 시작해야 한다', () => {
+      expect(LEVEL_THRESHOLDS[0].xpRequired).toBe(0);
+    });
+  });
+
+  describe('calculateLevel', () => {
+    it('0 XP는 레벨 1이어야 한다', () => {
+      const result = calculateLevel(0);
+      expect(result.level).toBe(1);
+      expect(result.tier).toBe('초보자');
+    });
+
+    it('100 XP는 레벨 2이어야 한다', () => {
+      const result = calculateLevel(100);
+      expect(result.level).toBe(2);
+    });
+
+    it('500 XP는 레벨 6이어야 한다 (중급자 시작)', () => {
+      const result = calculateLevel(500);
+      expect(result.level).toBe(6);
+      expect(result.tier).toBe('중급자');
+    });
+
+    it('1500 XP는 레벨 11이어야 한다 (숙련자 시작)', () => {
+      const result = calculateLevel(1500);
+      expect(result.level).toBe(11);
+      expect(result.tier).toBe('숙련자');
+    });
+
+    it('4500 XP는 레벨 21이어야 한다 (마스터 시작)', () => {
+      const result = calculateLevel(4500);
+      expect(result.level).toBe(21);
+      expect(result.tier).toBe('마스터');
+    });
+
+    it('5000 XP는 레벨 22이어야 한다', () => {
+      const result = calculateLevel(5000);
+      expect(result.level).toBe(22);
+      expect(result.tier).toBe('마스터');
+    });
+
+    it('진행률을 올바르게 계산해야 한다', () => {
+      // 레벨 1: 0-100 XP, 50 XP = 50%
+      const result = calculateLevel(50);
+      expect(result.level).toBe(1);
+      expect(result.currentXp).toBe(50);
+      expect(result.progress).toBeCloseTo(0.5, 1);
+    });
+  });
+
+  describe('calculateSessionXp', () => {
+    it('기본 훈련 완료 시 50 XP를 획득해야 한다', () => {
+      const result = calculateSessionXp({});
+      expect(result.total).toBe(50);
+      expect(result.breakdown.base).toBe(50);
+    });
+
+    it('완주 시 +20 XP 보너스를 획득해야 한다', () => {
+      const result = calculateSessionXp({ completed: true });
+      expect(result.total).toBe(70);
+      expect(result.breakdown.completionBonus).toBe(20);
+    });
+
+    it('연속일 보너스를 계산해야 한다 (streak × 5)', () => {
+      const result = calculateSessionXp({ streak: 7 });
+      expect(result.breakdown.streakBonus).toBe(35);
+      expect(result.total).toBe(85); // 50 + 35
+    });
+
+    it('배지 획득 보너스를 계산해야 한다', () => {
+      const result = calculateSessionXp({ newBadgeCount: 2 });
+      expect(result.breakdown.badgeBonus).toBe(200);
+      expect(result.total).toBe(250); // 50 + 200
+    });
+
+    it('모든 보너스를 합산해야 한다', () => {
+      const result = calculateSessionXp({
+        completed: true,
+        streak: 7,
+        newBadgeCount: 1
+      });
+      // 50 + 20 + 35 + 100 = 205
+      expect(result.total).toBe(205);
+    });
+  });
+
+  describe('addXp', () => {
+    it('XP를 추가해야 한다', () => {
+      const result = addXp(50, 30);
+      expect(result.newXp).toBe(80);
+    });
+
+    it('레벨업을 감지해야 한다', () => {
+      const result = addXp(90, 20); // 90 + 20 = 110 → 레벨 2
+      expect(result.oldLevel).toBe(1);
+      expect(result.newLevel).toBe(2);
+      expect(result.leveledUp).toBe(true);
+    });
+
+    it('레벨업이 없으면 leveledUp이 false이어야 한다', () => {
+      const result = addXp(50, 10);
+      expect(result.leveledUp).toBe(false);
+    });
+
+    it('여러 레벨을 한 번에 올라갈 수 있어야 한다', () => {
+      const result = addXp(0, 500); // 0 → 500 = 레벨 1 → 레벨 6
+      expect(result.oldLevel).toBe(1);
+      expect(result.newLevel).toBe(6);
+      expect(result.levelsGained).toBe(5);
+    });
+  });
+
+  describe('getLevelInfo', () => {
+    it('유효한 레벨 정보를 반환해야 한다', () => {
+      const info = getLevelInfo(5);
+      expect(info).not.toBeNull();
+      expect(info.level).toBe(5);
+      expect(info.xpRequired).toBe(400);
+      expect(info.tier).toBe('초보자');
+    });
+
+    it('레벨 21 이상도 정보를 반환해야 한다', () => {
+      const info = getLevelInfo(25);
+      expect(info.level).toBe(25);
+      expect(info.xpRequired).toBe(4500 + (4 * 500)); // 6500
+      expect(info.tier).toBe('마스터');
+    });
+
+    it('레벨 0 이하는 null을 반환해야 한다', () => {
+      expect(getLevelInfo(0)).toBeNull();
+      expect(getLevelInfo(-1)).toBeNull();
+    });
+  });
+});

--- a/tests/unit/milestones.test.js
+++ b/tests/unit/milestones.test.js
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import {
+  STREAK_MILESTONES,
+  SESSION_MILESTONES,
+  checkStreakMilestone,
+  checkSessionMilestone,
+  getLevelUpMessage,
+  checkAllMilestones,
+  getNextMilestone
+} from '../../src/gamification/milestones.js';
+
+describe('milestones', () => {
+  describe('STREAK_MILESTONES', () => {
+    it('7개의 연속일 마일스톤이 정의되어야 한다', () => {
+      expect(STREAK_MILESTONES).toHaveLength(7);
+    });
+
+    it('각 마일스톤은 days, emoji, message, description을 가져야 한다', () => {
+      STREAK_MILESTONES.forEach(m => {
+        expect(m).toHaveProperty('days');
+        expect(m).toHaveProperty('emoji');
+        expect(m).toHaveProperty('message');
+        expect(m).toHaveProperty('description');
+      });
+    });
+  });
+
+  describe('SESSION_MILESTONES', () => {
+    it('6개의 세션 마일스톤이 정의되어야 한다', () => {
+      expect(SESSION_MILESTONES).toHaveLength(6);
+    });
+  });
+
+  describe('checkStreakMilestone', () => {
+    it('7일 연속은 마일스톤이어야 한다', () => {
+      const milestone = checkStreakMilestone(7);
+      expect(milestone).not.toBeNull();
+      expect(milestone.days).toBe(7);
+      expect(milestone.emoji).toBe('⚔️');
+    });
+
+    it('30일 연속은 한 달의 기적이어야 한다', () => {
+      const milestone = checkStreakMilestone(30);
+      expect(milestone.message).toBe('한 달의 기적!');
+    });
+
+    it('마일스톤이 아닌 날짜는 null을 반환해야 한다', () => {
+      expect(checkStreakMilestone(5)).toBeNull();
+      expect(checkStreakMilestone(8)).toBeNull();
+    });
+  });
+
+  describe('checkSessionMilestone', () => {
+    it('첫 세션은 마일스톤이어야 한다', () => {
+      const milestone = checkSessionMilestone(1);
+      expect(milestone).not.toBeNull();
+      expect(milestone.emoji).toBe('🌱');
+    });
+
+    it('100회는 마일스톤이어야 한다', () => {
+      const milestone = checkSessionMilestone(100);
+      expect(milestone.emoji).toBe('💯');
+    });
+
+    it('마일스톤이 아닌 횟수는 null을 반환해야 한다', () => {
+      expect(checkSessionMilestone(5)).toBeNull();
+      expect(checkSessionMilestone(99)).toBeNull();
+    });
+  });
+
+  describe('getLevelUpMessage', () => {
+    it('레벨업 시 메시지를 반환해야 한다', () => {
+      const result = getLevelUpMessage(1, 2, '초보자');
+      expect(result.leveledUp).toBe(true);
+      expect(result.message).toBe('레벨 2 달성!');
+    });
+
+    it('레벨업이 없으면 leveledUp이 false이어야 한다', () => {
+      const result = getLevelUpMessage(5, 5, '초보자');
+      expect(result.leveledUp).toBe(false);
+      expect(result.message).toBeNull();
+    });
+
+    it('티어 변경 시 tierChanged가 true이어야 한다', () => {
+      const result = getLevelUpMessage(5, 6, '중급자');
+      expect(result.tierChanged).toBe(true);
+      expect(result.tierMessage).not.toBeNull();
+      expect(result.tierMessage.message).toBe('중급자로 승급!');
+    });
+
+    it('같은 티어 내 레벨업은 tierChanged가 false이어야 한다', () => {
+      const result = getLevelUpMessage(2, 3, '초보자');
+      expect(result.tierChanged).toBe(false);
+      expect(result.tierMessage).toBeNull();
+    });
+  });
+
+  describe('checkAllMilestones', () => {
+    it('모든 마일스톤을 한 번에 확인해야 한다', () => {
+      const result = checkAllMilestones({
+        streak: 7,
+        sessionCount: 10,
+        oldLevel: 1,
+        newLevel: 2,
+        newTier: '초보자',
+        newBadges: ['week_warrior']
+      });
+
+      expect(result.streakMilestone).not.toBeNull();
+      expect(result.sessionMilestone).not.toBeNull();
+      expect(result.levelUp.leveledUp).toBe(true);
+      expect(result.newBadges).toContain('week_warrior');
+    });
+
+    it('달성한 마일스톤이 없으면 null을 반환해야 한다', () => {
+      const result = checkAllMilestones({
+        streak: 2,
+        sessionCount: 5,
+        oldLevel: 3,
+        newLevel: 3,
+        newTier: '초보자',
+        newBadges: []
+      });
+
+      expect(result.streakMilestone).toBeNull();
+      expect(result.sessionMilestone).toBeNull();
+      expect(result.levelUp.leveledUp).toBe(false);
+      expect(result.newBadges).toHaveLength(0);
+    });
+  });
+
+  describe('getNextMilestone', () => {
+    it('다음 연속일 마일스톤을 반환해야 한다', () => {
+      const result = getNextMilestone(5, STREAK_MILESTONES, 'days');
+      expect(result).not.toBeNull();
+      expect(result.next.days).toBe(7);
+      expect(result.remaining).toBe(2);
+    });
+
+    it('다음 세션 마일스톤을 반환해야 한다', () => {
+      const result = getNextMilestone(8, SESSION_MILESTONES, 'count');
+      expect(result.next.count).toBe(10);
+      expect(result.remaining).toBe(2);
+    });
+
+    it('모든 마일스톤을 달성했으면 null을 반환해야 한다', () => {
+      const result = getNextMilestone(100, STREAK_MILESTONES, 'days');
+      expect(result).toBeNull();
+    });
+
+    it('현재 값이 0이면 첫 번째 마일스톤을 반환해야 한다', () => {
+      const result = getNextMilestone(0, SESSION_MILESTONES, 'count');
+      expect(result.next.count).toBe(1);
+      expect(result.remaining).toBe(1);
+    });
+  });
+});

--- a/tests/unit/sleep.test.js
+++ b/tests/unit/sleep.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getTodaySleep, getSleepByDate, saveSleep, getAllSleepData, resetSleepData } from '../../src/utils/sleep.js';
+import { createMockStorage } from '../setup.js';
+
+describe('sleep', () => {
+  const fixedNow = new Date('2026-03-11T10:00:00Z').getTime();
+  const today = '2026-03-11';
+  const yesterday = '2026-03-10';
+
+  describe('getTodaySleep', () => {
+    it('수면 데이터가 없으면 null을 반환해야 한다', () => {
+      const storage = createMockStorage();
+      expect(getTodaySleep(storage, fixedNow)).toBeNull();
+    });
+
+    it('오늘 수면 데이터를 반환해야 한다', () => {
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify({
+          [today]: { hours: 7, quality: 'good' }
+        })
+      });
+      expect(getTodaySleep(storage, fixedNow)).toEqual({ hours: 7, quality: 'good' });
+    });
+
+    it('어제 데이터만 있으면 null을 반환해야 한다', () => {
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify({
+          [yesterday]: { hours: 8, quality: 'great' }
+        })
+      });
+      expect(getTodaySleep(storage, fixedNow)).toBeNull();
+    });
+  });
+
+  describe('getSleepByDate', () => {
+    it('특정 날짜의 수면 데이터를 반환해야 한다', () => {
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify({
+          [yesterday]: { hours: 6, quality: 'bad' },
+          [today]: { hours: 7, quality: 'good' }
+        })
+      });
+      expect(getSleepByDate(yesterday, storage)).toEqual({ hours: 6, quality: 'bad' });
+    });
+
+    it('데이터가 없는 날짜는 null을 반환해야 한다', () => {
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify({
+          [today]: { hours: 7, quality: 'good' }
+        })
+      });
+      expect(getSleepByDate('2026-03-01', storage)).toBeNull();
+    });
+  });
+
+  describe('saveSleep', () => {
+    it('수면 데이터를 저장해야 한다', () => {
+      const storage = createMockStorage();
+      const result = saveSleep(7.5, 'great', storage, fixedNow);
+
+      expect(result).toEqual({ hours: 7.5, quality: 'great' });
+      expect(storage.setItem).toHaveBeenCalled();
+    });
+
+    it('기존 데이터를 유지하면서 오늘 데이터만 업데이트해야 한다', () => {
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify({
+          [yesterday]: { hours: 6, quality: 'bad' }
+        })
+      });
+      saveSleep(8, 'good', storage, fixedNow);
+
+      const savedData = JSON.parse(storage.setItem.mock.calls[0][1]);
+      expect(savedData[yesterday]).toEqual({ hours: 6, quality: 'bad' });
+      expect(savedData[today]).toEqual({ hours: 8, quality: 'good' });
+    });
+
+    it('같은 날 다시 저장하면 덮어써야 한다', () => {
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify({
+          [today]: { hours: 5, quality: 'bad' }
+        })
+      });
+      saveSleep(9, 'great', storage, fixedNow);
+
+      const savedData = JSON.parse(storage.setItem.mock.calls[0][1]);
+      expect(savedData[today]).toEqual({ hours: 9, quality: 'great' });
+    });
+  });
+
+  describe('getAllSleepData', () => {
+    it('모든 수면 데이터를 반환해야 한다', () => {
+      const sleepData = {
+        [yesterday]: { hours: 6, quality: 'bad' },
+        [today]: { hours: 7, quality: 'good' }
+      };
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify(sleepData)
+      });
+
+      expect(getAllSleepData(storage)).toEqual(sleepData);
+    });
+
+    it('데이터가 없으면 빈 객체를 반환해야 한다', () => {
+      const storage = createMockStorage();
+      expect(getAllSleepData(storage)).toEqual({});
+    });
+  });
+
+  describe('resetSleepData', () => {
+    it('수면 데이터를 삭제해야 한다', () => {
+      const storage = createMockStorage({
+        tongueSleep: JSON.stringify({ [today]: { hours: 7, quality: 'good' } })
+      });
+      resetSleepData(storage);
+
+      expect(storage.removeItem).toHaveBeenCalledWith('tongueSleep');
+    });
+  });
+});

--- a/tests/unit/streak.test.js
+++ b/tests/unit/streak.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadStreak, saveStreak, resetStreak } from '../../src/utils/streak.js';
+import { createMockStorage } from '../setup.js';
+
+describe('streak', () => {
+  // 고정 날짜: 2026-03-11 10:00:00 UTC (Wed Mar 11 2026)
+  const fixedNow = new Date('2026-03-11T10:00:00Z').getTime();
+  const today = 'Wed Mar 11 2026';
+  const yesterday = 'Tue Mar 10 2026';
+  const twoDaysAgo = 'Mon Mar 09 2026';
+
+  describe('loadStreak', () => {
+    it('저장된 데이터가 없으면 0을 반환해야 한다', () => {
+      const storage = createMockStorage();
+      expect(loadStreak(storage, fixedNow)).toBe(0);
+    });
+
+    it('오늘 훈련한 경우 저장된 streak을 반환해야 한다', () => {
+      const storage = createMockStorage({
+        tongueTraining: JSON.stringify({ lastDate: today, streak: 5 })
+      });
+      expect(loadStreak(storage, fixedNow)).toBe(5);
+    });
+
+    it('어제 훈련한 경우 저장된 streak을 반환해야 한다', () => {
+      const storage = createMockStorage({
+        tongueTraining: JSON.stringify({ lastDate: yesterday, streak: 3 })
+      });
+      expect(loadStreak(storage, fixedNow)).toBe(3);
+    });
+
+    it('2일 이상 지난 경우 0을 반환해야 한다', () => {
+      const storage = createMockStorage({
+        tongueTraining: JSON.stringify({ lastDate: twoDaysAgo, streak: 10 })
+      });
+      expect(loadStreak(storage, fixedNow)).toBe(0);
+    });
+
+    it('streak이 없으면 1을 반환해야 한다 (오늘 훈련)', () => {
+      const storage = createMockStorage({
+        tongueTraining: JSON.stringify({ lastDate: today })
+      });
+      expect(loadStreak(storage, fixedNow)).toBe(1);
+    });
+  });
+
+  describe('saveStreak', () => {
+    it('첫 훈련이면 streak 1을 저장해야 한다', () => {
+      const storage = createMockStorage();
+      const result = saveStreak(storage, fixedNow);
+
+      expect(result).toBe(1);
+      expect(storage.setItem).toHaveBeenCalledWith(
+        'tongueTraining',
+        expect.stringContaining('"streak":1')
+      );
+    });
+
+    it('어제 훈련한 경우 streak을 1 증가시켜야 한다', () => {
+      const storage = createMockStorage({
+        tongueTraining: JSON.stringify({ lastDate: yesterday, streak: 5 })
+      });
+      const result = saveStreak(storage, fixedNow);
+
+      expect(result).toBe(6);
+    });
+
+    it('오늘 이미 훈련한 경우 streak을 유지해야 한다', () => {
+      const storage = createMockStorage({
+        tongueTraining: JSON.stringify({ lastDate: today, streak: 5 })
+      });
+      const result = saveStreak(storage, fixedNow);
+
+      expect(result).toBe(5);
+    });
+
+    it('연속이 끊긴 경우 streak을 1로 리셋해야 한다', () => {
+      const storage = createMockStorage({
+        tongueTraining: JSON.stringify({ lastDate: twoDaysAgo, streak: 10 })
+      });
+      const result = saveStreak(storage, fixedNow);
+
+      expect(result).toBe(1);
+    });
+
+    it('lastDate를 오늘로 업데이트해야 한다', () => {
+      const storage = createMockStorage();
+      saveStreak(storage, fixedNow);
+
+      const savedData = JSON.parse(storage.setItem.mock.calls[0][1]);
+      expect(savedData.lastDate).toBe(today);
+    });
+  });
+
+  describe('resetStreak', () => {
+    it('tongueTraining 데이터를 삭제해야 한다', () => {
+      const storage = createMockStorage({
+        tongueTraining: JSON.stringify({ lastDate: today, streak: 5 })
+      });
+      resetStreak(storage);
+
+      expect(storage.removeItem).toHaveBeenCalledWith('tongueTraining');
+    });
+  });
+});

--- a/tests/unit/sw-helpers.test.js
+++ b/tests/unit/sw-helpers.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isStaticAsset,
+  isExternalResource,
+  getOfflineHtml,
+  STATIC_ASSETS,
+  EXTERNAL_PATTERNS
+} from '../../src/sw/helpers.js';
+
+describe('sw helpers', () => {
+  describe('STATIC_ASSETS', () => {
+    it('기본 정적 리소스 목록을 포함해야 한다', () => {
+      expect(STATIC_ASSETS).toContain('/');
+      expect(STATIC_ASSETS).toContain('/tongue-training.html');
+      expect(STATIC_ASSETS).toContain('/manifest.json');
+      expect(STATIC_ASSETS).toContain('/icons/icon.svg');
+    });
+  });
+
+  describe('EXTERNAL_PATTERNS', () => {
+    it('외부 리소스 패턴을 포함해야 한다', () => {
+      expect(EXTERNAL_PATTERNS).toContain('fonts.googleapis.com');
+      expect(EXTERNAL_PATTERNS).toContain('fonts.gstatic.com');
+      expect(EXTERNAL_PATTERNS).toContain('unpkg.com/@splinetool');
+    });
+  });
+
+  describe('isStaticAsset', () => {
+    it('STATIC_ASSETS에 포함된 경로는 true를 반환해야 한다', () => {
+      expect(isStaticAsset('/')).toBe(true);
+      expect(isStaticAsset('/tongue-training.html')).toBe(true);
+      expect(isStaticAsset('/manifest.json')).toBe(true);
+      expect(isStaticAsset('/icons/icon.svg')).toBe(true);
+    });
+
+    it('.html 파일은 true를 반환해야 한다', () => {
+      expect(isStaticAsset('/other-page.html')).toBe(true);
+      expect(isStaticAsset('/pages/about.html')).toBe(true);
+    });
+
+    it('.css 파일은 true를 반환해야 한다', () => {
+      expect(isStaticAsset('/styles.css')).toBe(true);
+      expect(isStaticAsset('/css/main.css')).toBe(true);
+    });
+
+    it('.js 파일은 true를 반환해야 한다', () => {
+      expect(isStaticAsset('/app.js')).toBe(true);
+      expect(isStaticAsset('/src/utils/date.js')).toBe(true);
+    });
+
+    it('.svg 파일은 true를 반환해야 한다', () => {
+      expect(isStaticAsset('/icon.svg')).toBe(true);
+      expect(isStaticAsset('/images/logo.svg')).toBe(true);
+    });
+
+    it('.png 파일은 true를 반환해야 한다', () => {
+      expect(isStaticAsset('/image.png')).toBe(true);
+      expect(isStaticAsset('/icons/icon-192.png')).toBe(true);
+    });
+
+    it('.ico 파일은 true를 반환해야 한다', () => {
+      expect(isStaticAsset('/favicon.ico')).toBe(true);
+    });
+
+    it('API 경로는 false를 반환해야 한다', () => {
+      expect(isStaticAsset('/api/data')).toBe(false);
+      expect(isStaticAsset('/api/sessions')).toBe(false);
+    });
+
+    it('.jpg, .webp 등 지원하지 않는 확장자는 false를 반환해야 한다', () => {
+      expect(isStaticAsset('/image.jpg')).toBe(false);
+      expect(isStaticAsset('/photo.webp')).toBe(false);
+      expect(isStaticAsset('/video.mp4')).toBe(false);
+    });
+
+    it('커스텀 정적 리소스 목록을 사용할 수 있어야 한다', () => {
+      const customAssets = ['/custom.html'];
+      expect(isStaticAsset('/custom.html', customAssets)).toBe(true);
+      expect(isStaticAsset('/', customAssets)).toBe(false);
+    });
+  });
+
+  describe('isExternalResource', () => {
+    it('구글 폰트 URL은 true를 반환해야 한다', () => {
+      expect(isExternalResource('https://fonts.googleapis.com/css2?family=Inter')).toBe(true);
+      expect(isExternalResource('https://fonts.gstatic.com/s/inter/v13/font.woff2')).toBe(true);
+    });
+
+    it('Spline URL은 true를 반환해야 한다', () => {
+      expect(isExternalResource('https://unpkg.com/@splinetool/viewer@1.9.82/build/spline-viewer.js')).toBe(true);
+    });
+
+    it('다른 외부 URL은 false를 반환해야 한다', () => {
+      expect(isExternalResource('https://example.com/resource')).toBe(false);
+      expect(isExternalResource('https://cdn.jsdelivr.net/npm/library')).toBe(false);
+    });
+
+    it('로컬 URL은 false를 반환해야 한다', () => {
+      expect(isExternalResource('http://localhost:3000/api')).toBe(false);
+      expect(isExternalResource('/tongue-training.html')).toBe(false);
+    });
+
+    it('커스텀 패턴 목록을 사용할 수 있어야 한다', () => {
+      const customPatterns = ['cdn.example.com'];
+      expect(isExternalResource('https://cdn.example.com/lib.js', customPatterns)).toBe(true);
+      expect(isExternalResource('https://fonts.googleapis.com/css', customPatterns)).toBe(false);
+    });
+  });
+
+  describe('getOfflineHtml', () => {
+    it('HTML 문자열을 반환해야 한다', () => {
+      const html = getOfflineHtml();
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('<html lang="ko">');
+    });
+
+    it('오프라인 메시지를 포함해야 한다', () => {
+      const html = getOfflineHtml();
+      expect(html).toContain('오프라인');
+    });
+
+    it('새로고침 버튼을 포함해야 한다', () => {
+      const html = getOfflineHtml();
+      expect(html).toContain('다시 시도');
+      expect(html).toContain('location.reload()');
+    });
+  });
+});

--- a/tongue-training.html
+++ b/tongue-training.html
@@ -251,6 +251,173 @@
             margin-bottom: 32px;
         }
 
+        /* 게이미피케이션 배지 컨테이너 */
+        .gamification-badges {
+            display: flex;
+            justify-content: center;
+            gap: 12px;
+            margin-bottom: 32px;
+            flex-wrap: wrap;
+        }
+
+        .gamification-badges .streak-badge {
+            margin-bottom: 0;
+        }
+
+        /* 레벨 배지 */
+        .level-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 8px 16px;
+            background: rgba(99, 102, 241, 0.15);
+            border: 1px solid rgba(99, 102, 241, 0.3);
+            border-radius: 100px;
+            font-size: 0.85rem;
+            color: #818cf8;
+        }
+
+        .level-badge .tier {
+            font-size: 0.7rem;
+            opacity: 0.7;
+        }
+
+        /* XP 프로그레스 바 */
+        .xp-progress {
+            width: 100%;
+            max-width: 200px;
+            height: 4px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 2px;
+            overflow: hidden;
+            margin: 8px auto 0;
+        }
+
+        .xp-progress-bar {
+            height: 100%;
+            background: linear-gradient(90deg, #6366f1, #8b5cf6);
+            border-radius: 2px;
+            transition: width 0.5s ease;
+        }
+
+        /* 토스트 알림 */
+        .toast-container {
+            position: fixed;
+            top: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 1000;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            pointer-events: none;
+        }
+
+        .toast {
+            background: rgba(15, 15, 20, 0.95);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 16px;
+            padding: 16px 24px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            animation: toastIn 0.3s ease, toastOut 0.3s ease 2.7s forwards;
+            backdrop-filter: blur(20px);
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+        }
+
+        .toast.badge-toast {
+            border-color: rgba(251, 191, 36, 0.3);
+        }
+
+        .toast.milestone-toast {
+            border-color: rgba(99, 102, 241, 0.3);
+        }
+
+        .toast.levelup-toast {
+            border-color: rgba(139, 92, 246, 0.3);
+        }
+
+        .toast-emoji {
+            font-size: 2rem;
+        }
+
+        .toast-content {
+            text-align: left;
+        }
+
+        .toast-title {
+            font-weight: 600;
+            font-size: 1rem;
+            color: #fff;
+        }
+
+        .toast-desc {
+            font-size: 0.8rem;
+            color: rgba(255, 255, 255, 0.6);
+            margin-top: 2px;
+        }
+
+        @keyframes toastIn {
+            from {
+                opacity: 0;
+                transform: translateY(-20px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @keyframes toastOut {
+            from {
+                opacity: 1;
+                transform: translateY(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateY(-20px);
+            }
+        }
+
+        /* XP 획득 표시 (완료 화면) */
+        .xp-earned {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 8px;
+            margin-top: 24px;
+            padding: 16px;
+            background: rgba(99, 102, 241, 0.1);
+            border-radius: 16px;
+            border: 1px solid rgba(99, 102, 241, 0.2);
+        }
+
+        .xp-earned-value {
+            font-size: 2rem;
+            font-weight: 700;
+            color: #8b5cf6;
+        }
+
+        .xp-earned-label {
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .xp-breakdown {
+            display: flex;
+            gap: 16px;
+            font-size: 0.75rem;
+            color: rgba(255, 255, 255, 0.5);
+            margin-top: 8px;
+        }
+
+        .xp-breakdown span {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
         /* ========== 훈련 화면 ========== */
         .training-screen {
             display: none;
@@ -1273,6 +1440,9 @@
     </style>
 </head>
 <body>
+    <!-- 토스트 알림 컨테이너 -->
+    <div class="toast-container" id="toastContainer"></div>
+
     <!-- 배경 오브 -->
     <div class="bg-orbs">
         <div class="orb orb-1"></div>
@@ -1302,8 +1472,17 @@
         <div class="glass-card start-screen" id="startScreen">
             <div class="logo">Tongue Training</div>
 
-            <div class="streak-badge" id="streakBadge">
-                🔥 <span id="streakCount">0</span>일 연속
+            <div class="gamification-badges">
+                <div class="streak-badge" id="streakBadge">
+                    🔥 <span id="streakCount">0</span>일 연속
+                </div>
+                <div class="level-badge" id="levelBadge">
+                    ⭐ Lv.<span id="levelDisplay">1</span>
+                    <span class="tier" id="tierDisplay">초보자</span>
+                </div>
+            </div>
+            <div class="xp-progress" id="xpProgressContainer">
+                <div class="xp-progress-bar" id="xpProgressBar" style="width: 0%"></div>
             </div>
 
             <h1 class="main-title">오늘의 훈련</h1>
@@ -1459,6 +1638,16 @@
                 <div class="stat-item">
                     <div class="stat-value" id="newStreak">1</div>
                     <div class="stat-label">연속일</div>
+                </div>
+            </div>
+
+            <div class="xp-earned" id="xpEarned">
+                <div class="xp-earned-value">+<span id="xpGained">70</span> XP</div>
+                <div class="xp-earned-label">경험치 획득</div>
+                <div class="xp-breakdown" id="xpBreakdown">
+                    <span>🎯 기본 50</span>
+                    <span>✓ 완주 +20</span>
+                    <span id="streakBonus">🔥 연속 +5</span>
                 </div>
             </div>
 
@@ -1662,6 +1851,14 @@
             totalTime: $('totalTime'),
             totalReps: $('totalReps'),
             newStreak: $('newStreak'),
+            // 게이미피케이션
+            levelDisplay: $('levelDisplay'),
+            tierDisplay: $('tierDisplay'),
+            xpProgressBar: $('xpProgressBar'),
+            toastContainer: $('toastContainer'),
+            xpGained: $('xpGained'),
+            xpBreakdown: $('xpBreakdown'),
+            streakBonus: $('streakBonus'),
             splineViewer: $('splineViewer'),
             splineContainer: $('splineContainer'),
             splineLoading: $('splineLoading'),
@@ -1759,6 +1956,277 @@
             const today = new Date().toISOString().split('T')[0];
             data[today] = { hours, quality };
             localStorage.setItem('tongueSleep', JSON.stringify(data));
+        }
+
+        // ========== 게이미피케이션 ==========
+        const PROFILE_KEY = 'tongueProfile';
+
+        function loadProfile() {
+            const data = localStorage.getItem(PROFILE_KEY);
+            if (!data) {
+                return { xp: 0, level: 1, badges: [], badgeNotified: [] };
+            }
+            return JSON.parse(data);
+        }
+
+        function saveProfile(profile) {
+            localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+        }
+
+        // XP 계산
+        const XP_VALUES = {
+            SESSION_COMPLETE: 50,
+            FULL_COMPLETE_BONUS: 20,
+            STREAK_MULTIPLIER: 5,
+            BADGE_EARNED: 100
+        };
+
+        // 레벨 테이블
+        const LEVEL_THRESHOLDS = [
+            { level: 1, xpRequired: 0, tier: '초보자' },
+            { level: 2, xpRequired: 100, tier: '초보자' },
+            { level: 3, xpRequired: 200, tier: '초보자' },
+            { level: 4, xpRequired: 300, tier: '초보자' },
+            { level: 5, xpRequired: 400, tier: '초보자' },
+            { level: 6, xpRequired: 500, tier: '중급자' },
+            { level: 7, xpRequired: 700, tier: '중급자' },
+            { level: 8, xpRequired: 900, tier: '중급자' },
+            { level: 9, xpRequired: 1100, tier: '중급자' },
+            { level: 10, xpRequired: 1300, tier: '중급자' },
+            { level: 11, xpRequired: 1500, tier: '숙련자' },
+            { level: 12, xpRequired: 1800, tier: '숙련자' },
+            { level: 13, xpRequired: 2100, tier: '숙련자' },
+            { level: 14, xpRequired: 2400, tier: '숙련자' },
+            { level: 15, xpRequired: 2700, tier: '숙련자' },
+            { level: 16, xpRequired: 3000, tier: '숙련자' },
+            { level: 17, xpRequired: 3300, tier: '숙련자' },
+            { level: 18, xpRequired: 3600, tier: '숙련자' },
+            { level: 19, xpRequired: 3900, tier: '숙련자' },
+            { level: 20, xpRequired: 4200, tier: '숙련자' },
+            { level: 21, xpRequired: 4500, tier: '마스터' }
+        ];
+
+        function calculateLevel(xp) {
+            let levelInfo = LEVEL_THRESHOLDS[0];
+            for (let i = LEVEL_THRESHOLDS.length - 1; i >= 0; i--) {
+                if (xp >= LEVEL_THRESHOLDS[i].xpRequired) {
+                    levelInfo = LEVEL_THRESHOLDS[i];
+                    break;
+                }
+            }
+            // 레벨 21 이상
+            if (xp >= 4500) {
+                const xpAbove21 = xp - 4500;
+                const extraLevels = Math.floor(xpAbove21 / 500);
+                levelInfo = {
+                    level: 21 + extraLevels,
+                    tier: '마스터',
+                    xpRequired: 4500 + (extraLevels * 500)
+                };
+            }
+
+            const currentLevelIndex = LEVEL_THRESHOLDS.findIndex(t => t.level === Math.min(levelInfo.level, 21));
+            let nextLevelXp;
+            if (currentLevelIndex < LEVEL_THRESHOLDS.length - 1 && levelInfo.level <= 20) {
+                nextLevelXp = LEVEL_THRESHOLDS[currentLevelIndex + 1].xpRequired;
+            } else {
+                nextLevelXp = levelInfo.xpRequired + 500;
+            }
+
+            const currentXp = xp - levelInfo.xpRequired;
+            const xpForNextLevel = nextLevelXp - levelInfo.xpRequired;
+            const progress = xpForNextLevel > 0 ? currentXp / xpForNextLevel : 1;
+
+            return {
+                level: levelInfo.level,
+                tier: levelInfo.tier,
+                totalXp: xp,
+                currentXp,
+                nextLevelXp,
+                xpForNextLevel,
+                progress: Math.min(progress, 1)
+            };
+        }
+
+        function calculateSessionXp(completed, streak, newBadgeCount) {
+            const base = XP_VALUES.SESSION_COMPLETE;
+            const completionBonus = completed ? XP_VALUES.FULL_COMPLETE_BONUS : 0;
+            const streakBonus = streak * XP_VALUES.STREAK_MULTIPLIER;
+            const badgeBonus = newBadgeCount * XP_VALUES.BADGE_EARNED;
+            return {
+                total: base + completionBonus + streakBonus + badgeBonus,
+                breakdown: { base, completionBonus, streakBonus, badgeBonus }
+            };
+        }
+
+        // 배지 정의
+        const BADGES = [
+            { id: 'first_step',    emoji: '🌱', name: '첫 걸음',     description: '첫 훈련 완료' },
+            { id: 'week_warrior',  emoji: '⚔️', name: '일주일 전사', description: '7일 연속 훈련' },
+            { id: 'month_miracle', emoji: '🏆', name: '한 달의 기적', description: '30일 연속 훈련' },
+            { id: 'morning_bird',  emoji: '🌅', name: '아침형 인간', description: '오전 6-9시 훈련 10회' },
+            { id: 'night_owl',     emoji: '🦉', name: '올빼미',       description: '밤 9시 후 훈련 10회' },
+            { id: 'sleep_master',  emoji: '😴', name: '수면 마스터', description: '7시간+ 수면 후 훈련 10회' },
+            { id: 'century',       emoji: '💯', name: '100회 달성',  description: '총 100회 훈련' },
+            { id: 'champion',      emoji: '👑', name: '혀 근력왕',   description: '8주 프로그램 완주' }
+        ];
+
+        function getBadgeById(id) {
+            return BADGES.find(b => b.id === id) || null;
+        }
+
+        function calculateBadgeStats(history, sleepData, maxStreak) {
+            let morningCount = 0, eveningCount = 0, goodSleepCount = 0;
+            history.forEach(s => {
+                const hour = new Date(s.timestamp).getHours();
+                if (hour >= 6 && hour < 9) morningCount++;
+                if (hour >= 21 || hour < 5) eveningCount++;
+                const sleep = sleepData[s.date];
+                if (sleep && parseFloat(sleep.hours) >= 7) goodSleepCount++;
+            });
+
+            let programWeeks = 0;
+            if (history.length > 0) {
+                const sortedDates = [...new Set(history.map(s => s.date))].sort();
+                const firstDate = new Date(sortedDates[0]);
+                const lastDate = new Date(sortedDates[sortedDates.length - 1]);
+                programWeeks = Math.floor((lastDate - firstDate) / (1000 * 60 * 60 * 24 * 7)) + 1;
+            }
+
+            return { totalSessions: history.length, maxStreak, morningCount, eveningCount, goodSleepCount, programWeeks };
+        }
+
+        function getEarnedBadges(stats) {
+            const earned = [];
+            if (stats.totalSessions >= 1) earned.push('first_step');
+            if (stats.maxStreak >= 7) earned.push('week_warrior');
+            if (stats.maxStreak >= 30) earned.push('month_miracle');
+            if (stats.morningCount >= 10) earned.push('morning_bird');
+            if (stats.eveningCount >= 10) earned.push('night_owl');
+            if (stats.goodSleepCount >= 10) earned.push('sleep_master');
+            if (stats.totalSessions >= 100) earned.push('century');
+            if (stats.programWeeks >= 8) earned.push('champion');
+            return earned;
+        }
+
+        // 마일스톤
+        const STREAK_MILESTONES = [
+            { days: 3,  emoji: '🔥', message: '3일 연속 달성!' },
+            { days: 7,  emoji: '⚔️', message: '일주일 전사!' },
+            { days: 14, emoji: '🌟', message: '2주 연속!' },
+            { days: 21, emoji: '💪', message: '21일 습관 형성!' },
+            { days: 30, emoji: '🏆', message: '한 달의 기적!' },
+            { days: 60, emoji: '👑', message: '60일 마스터!' },
+            { days: 100, emoji: '💯', message: '100일 전설!' }
+        ];
+
+        const SESSION_MILESTONES = [
+            { count: 1,   emoji: '🌱', message: '첫 훈련 완료!' },
+            { count: 10,  emoji: '⭐', message: '10회 달성!' },
+            { count: 25,  emoji: '🎯', message: '25회 달성!' },
+            { count: 50,  emoji: '🎖️', message: '50회 달성!' },
+            { count: 100, emoji: '💯', message: '100회 달성!' }
+        ];
+
+        function checkMilestone(value, milestones, key) {
+            return milestones.find(m => m[key] === value) || null;
+        }
+
+        // 토스트 알림
+        function showToast(emoji, title, desc, type = '') {
+            const toast = document.createElement('div');
+            toast.className = `toast ${type}`;
+            toast.innerHTML = `
+                <div class="toast-emoji">${emoji}</div>
+                <div class="toast-content">
+                    <div class="toast-title">${title}</div>
+                    <div class="toast-desc">${desc}</div>
+                </div>
+            `;
+            el.toastContainer.appendChild(toast);
+            setTimeout(() => toast.remove(), 3000);
+        }
+
+        // UI 업데이트
+        function updateLevelDisplay() {
+            const profile = loadProfile();
+            const levelInfo = calculateLevel(profile.xp);
+            el.levelDisplay.textContent = levelInfo.level;
+            el.tierDisplay.textContent = levelInfo.tier;
+            el.xpProgressBar.style.width = (levelInfo.progress * 100) + '%';
+        }
+
+        // 훈련 완료 시 게이미피케이션 처리
+        function processGamification(streak, completed) {
+            const profile = loadProfile();
+            const history = getHistory();
+            const sleepData = JSON.parse(localStorage.getItem('tongueSleep') || '{}');
+
+            // 배지 통계 계산 (history에 현재 세션 포함됨)
+            const maxStreak = Math.max(streak, profile.maxStreak || 0);
+            const badgeStats = calculateBadgeStats(history, sleepData, maxStreak);
+            const earnedBadges = getEarnedBadges(badgeStats);
+            const newBadges = earnedBadges.filter(b => !profile.badges.includes(b));
+
+            // XP 계산
+            const xpResult = calculateSessionXp(completed, streak, newBadges.length);
+            const oldLevel = calculateLevel(profile.xp).level;
+            profile.xp += xpResult.total;
+            profile.maxStreak = maxStreak;
+            profile.badges = earnedBadges;
+
+            const newLevelInfo = calculateLevel(profile.xp);
+            const leveledUp = newLevelInfo.level > oldLevel;
+
+            saveProfile(profile);
+
+            // XP 표시 업데이트
+            el.xpGained.textContent = xpResult.total;
+            el.streakBonus.textContent = `🔥 연속 +${xpResult.breakdown.streakBonus}`;
+
+            // 레벨 표시 업데이트
+            updateLevelDisplay();
+
+            // 토스트 알림 (지연 표시)
+            let delay = 500;
+
+            // 새 배지 알림
+            newBadges.forEach(badgeId => {
+                const badge = getBadgeById(badgeId);
+                if (badge) {
+                    setTimeout(() => {
+                        showToast(badge.emoji, badge.name, badge.description, 'badge-toast');
+                    }, delay);
+                    delay += 800;
+                }
+            });
+
+            // 연속일 마일스톤
+            const streakMilestone = checkMilestone(streak, STREAK_MILESTONES, 'days');
+            if (streakMilestone) {
+                setTimeout(() => {
+                    showToast(streakMilestone.emoji, streakMilestone.message, `${streak}일 연속 훈련!`, 'milestone-toast');
+                }, delay);
+                delay += 800;
+            }
+
+            // 세션 마일스톤
+            const sessionMilestone = checkMilestone(history.length, SESSION_MILESTONES, 'count');
+            if (sessionMilestone) {
+                setTimeout(() => {
+                    showToast(sessionMilestone.emoji, sessionMilestone.message, `총 ${history.length}회 훈련 완료`, 'milestone-toast');
+                }, delay);
+                delay += 800;
+            }
+
+            // 레벨업 알림
+            if (leveledUp) {
+                setTimeout(() => {
+                    showToast('⬆️', `레벨 ${newLevelInfo.level} 달성!`, newLevelInfo.tier, 'levelup-toast');
+                }, delay);
+            }
+
+            return { xpResult, newBadges, leveledUp, newLevel: newLevelInfo.level };
         }
 
         // ========== 대시보드 ==========
@@ -2344,6 +2812,10 @@
             // 세션 히스토리 저장
             saveSession(elapsed, TOTAL_REPS);
 
+            // 게이미피케이션 처리
+            const completed = (state.currentRep >= TOTAL_REPS);
+            processGamification(streak, completed);
+
             el.trainingScreen.classList.remove('show');
             el.completeScreen.classList.add('show');
 
@@ -2553,6 +3025,7 @@
         // ========== 초기화 ==========
         function init() {
             el.streakCount.textContent = loadStreak();
+            updateLevelDisplay();  // 게이미피케이션 레벨 표시
             window.speechSynthesis.getVoices();
             initSpline();
             registerServiceWorker();

--- a/tongue-training.html
+++ b/tongue-training.html
@@ -1,0 +1,1010 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>혀 훈련 - 8분 루틴</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        :root {
+            --primary: #6366f1;
+            --primary-dark: #4f46e5;
+            --success: #22c55e;
+            --bg: #0f172a;
+            --card: #1e293b;
+            --text: #f8fafc;
+            --text-muted: #94a3b8;
+        }
+
+        body {
+            font-family: -apple-system, 'SF Pro Display', 'Pretendard', 'Apple SD Gothic Neo', sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+            overflow: hidden;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 420px;
+            text-align: center;
+        }
+
+        /* 헤더 */
+        .header {
+            margin-bottom: 20px;
+        }
+
+        .title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            margin-bottom: 8px;
+        }
+
+        .streak-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: linear-gradient(135deg, #f97316, #ef4444);
+            padding: 6px 14px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            font-weight: 600;
+        }
+
+        /* 메인 애니메이션 영역 */
+        .animation-area {
+            background: var(--card);
+            border-radius: 24px;
+            padding: 40px 20px;
+            margin-bottom: 20px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .mouth-container {
+            width: 200px;
+            height: 200px;
+            margin: 0 auto 20px;
+            position: relative;
+        }
+
+        /* 입 모양 */
+        .mouth {
+            width: 180px;
+            height: 120px;
+            background: #1a1a2e;
+            border-radius: 50% 50% 50% 50% / 30% 30% 70% 70%;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            border: 4px solid #ff6b9d;
+            overflow: hidden;
+            transition: all 0.3s ease;
+        }
+
+        .mouth.open {
+            height: 140px;
+            border-radius: 50% 50% 50% 50% / 20% 20% 80% 80%;
+        }
+
+        /* 혀 */
+        .tongue {
+            width: 80px;
+            height: 100px;
+            background: linear-gradient(180deg, #ff6b9d 0%, #e91e63 100%);
+            border-radius: 50% 50% 50% 50% / 40% 40% 60% 60%;
+            position: absolute;
+            bottom: -20px;
+            left: 50%;
+            transform: translateX(-50%);
+            transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+        }
+
+        /* 혀 올리기 애니메이션 */
+        .tongue.up {
+            bottom: 60px;
+            height: 60px;
+            border-radius: 50%;
+            box-shadow: 0 -10px 20px rgba(233, 30, 99, 0.5);
+        }
+
+        /* 혀 내밀기 애니메이션 */
+        .tongue.out {
+            bottom: -60px;
+            height: 140px;
+            border-radius: 45% 45% 50% 50% / 30% 30% 70% 70%;
+        }
+
+        /* 혀 클릭 애니메이션 */
+        .tongue.click {
+            animation: tongueClick 0.3s ease;
+        }
+
+        @keyframes tongueClick {
+            0% { bottom: -20px; }
+            50% { bottom: 40px; transform: translateX(-50%) scale(1.1); }
+            100% { bottom: -20px; }
+        }
+
+        /* 입천장 표시 */
+        .palate {
+            position: absolute;
+            top: 10px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 100px;
+            height: 30px;
+            background: linear-gradient(180deg, #2d1f3d 0%, #1a1a2e 100%);
+            border-radius: 0 0 50% 50%;
+            opacity: 0;
+            transition: opacity 0.3s;
+        }
+
+        .mouth.open .palate {
+            opacity: 1;
+        }
+
+        /* 운동 이름 */
+        .exercise-name {
+            font-size: 1.8rem;
+            font-weight: 700;
+            margin-bottom: 10px;
+            color: var(--primary);
+        }
+
+        .exercise-instruction {
+            font-size: 1.1rem;
+            color: var(--text-muted);
+            line-height: 1.6;
+            min-height: 50px;
+        }
+
+        /* 타이머 영역 */
+        .timer-section {
+            margin-bottom: 24px;
+        }
+
+        .timer-display {
+            font-size: 4rem;
+            font-weight: 700;
+            font-variant-numeric: tabular-nums;
+            margin-bottom: 12px;
+        }
+
+        .timer-display.counting {
+            color: var(--primary);
+        }
+
+        .timer-display.rest {
+            color: var(--success);
+        }
+
+        /* 프로그레스 바 */
+        .progress-container {
+            background: var(--card);
+            border-radius: 10px;
+            height: 12px;
+            overflow: hidden;
+            margin-bottom: 8px;
+        }
+
+        .progress-bar {
+            height: 100%;
+            background: linear-gradient(90deg, var(--primary), #8b5cf6);
+            border-radius: 10px;
+            transition: width 0.3s ease;
+        }
+
+        .progress-text {
+            font-size: 0.9rem;
+            color: var(--text-muted);
+        }
+
+        /* 반복 카운터 */
+        .rep-counter {
+            display: flex;
+            justify-content: center;
+            gap: 8px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .rep-dot {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--card);
+            border: 2px solid var(--text-muted);
+            transition: all 0.3s;
+        }
+
+        .rep-dot.completed {
+            background: var(--success);
+            border-color: var(--success);
+            transform: scale(1.1);
+        }
+
+        .rep-dot.current {
+            border-color: var(--primary);
+            box-shadow: 0 0 10px var(--primary);
+            animation: pulse 1s infinite;
+        }
+
+        @keyframes pulse {
+            0%, 100% { transform: scale(1); }
+            50% { transform: scale(1.2); }
+        }
+
+        /* 버튼 */
+        .btn {
+            width: 100%;
+            padding: 18px 32px;
+            font-size: 1.2rem;
+            font-weight: 700;
+            border: none;
+            border-radius: 16px;
+            cursor: pointer;
+            transition: all 0.3s;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+        }
+
+        .btn-primary {
+            background: linear-gradient(135deg, var(--primary), #8b5cf6);
+            color: white;
+            box-shadow: 0 4px 20px rgba(99, 102, 241, 0.4);
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 30px rgba(99, 102, 241, 0.5);
+        }
+
+        .btn-primary:active {
+            transform: translateY(0);
+        }
+
+        .btn-success {
+            background: linear-gradient(135deg, var(--success), #16a34a);
+            color: white;
+        }
+
+        .btn-secondary {
+            background: var(--card);
+            color: var(--text);
+            border: 2px solid var(--text-muted);
+        }
+
+        .btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            transform: none;
+        }
+
+        /* 완료 화면 */
+        .complete-screen {
+            display: none;
+            text-align: center;
+            padding: 40px 20px;
+        }
+
+        .complete-screen.show {
+            display: block;
+            animation: fadeIn 0.5s ease;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: scale(0.9); }
+            to { opacity: 1; transform: scale(1); }
+        }
+
+        .complete-icon {
+            font-size: 5rem;
+            margin-bottom: 20px;
+        }
+
+        .complete-title {
+            font-size: 2rem;
+            font-weight: 700;
+            margin-bottom: 10px;
+            background: linear-gradient(135deg, var(--success), #22d3ee);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .complete-stats {
+            color: var(--text-muted);
+            margin-bottom: 30px;
+        }
+
+        /* 시작 화면 */
+        .start-screen {
+            text-align: center;
+        }
+
+        .start-screen .exercise-preview {
+            background: var(--card);
+            border-radius: 16px;
+            padding: 20px;
+            margin-bottom: 20px;
+        }
+
+        .exercise-list {
+            text-align: left;
+        }
+
+        .exercise-item {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 12px 0;
+            border-bottom: 1px solid rgba(255,255,255,0.1);
+        }
+
+        .exercise-item:last-child {
+            border-bottom: none;
+        }
+
+        .exercise-number {
+            width: 32px;
+            height: 32px;
+            background: var(--primary);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            font-size: 0.9rem;
+        }
+
+        .exercise-info {
+            flex: 1;
+        }
+
+        .exercise-info-name {
+            font-weight: 600;
+            margin-bottom: 2px;
+        }
+
+        .exercise-info-detail {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        /* 훈련 화면 */
+        .training-screen {
+            display: none;
+        }
+
+        .training-screen.show {
+            display: block;
+        }
+
+        /* 숨김 */
+        .hidden {
+            display: none !important;
+        }
+
+        /* 음성 토글 */
+        .voice-toggle {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: var(--card);
+            border: none;
+            border-radius: 50%;
+            width: 48px;
+            height: 48px;
+            font-size: 1.5rem;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+
+        .voice-toggle:hover {
+            background: var(--primary);
+        }
+
+        /* 카운트다운 오버레이 */
+        .countdown-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(15, 23, 42, 0.95);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 100;
+        }
+
+        .countdown-overlay.show {
+            display: flex;
+        }
+
+        .countdown-number {
+            font-size: 8rem;
+            font-weight: 700;
+            color: var(--primary);
+            animation: countdownPop 1s ease;
+        }
+
+        @keyframes countdownPop {
+            0% { transform: scale(0.5); opacity: 0; }
+            50% { transform: scale(1.2); }
+            100% { transform: scale(1); opacity: 1; }
+        }
+
+        /* 반응형 */
+        @media (max-width: 380px) {
+            .timer-display {
+                font-size: 3rem;
+            }
+
+            .mouth-container {
+                width: 160px;
+                height: 160px;
+            }
+
+            .mouth {
+                width: 140px;
+                height: 100px;
+            }
+
+            .tongue {
+                width: 60px;
+                height: 80px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <button class="voice-toggle" id="voiceToggle" title="음성 켜기/끄기">
+        🔊
+    </button>
+
+    <div class="container">
+        <!-- 시작 화면 -->
+        <div class="start-screen" id="startScreen">
+            <div class="header">
+                <h1 class="title">오늘의 혀 훈련</h1>
+                <div class="streak-badge" id="streakBadge">
+                    🔥 <span id="streakCount">0</span>일 연속
+                </div>
+            </div>
+
+            <div class="exercise-preview">
+                <div class="exercise-list">
+                    <div class="exercise-item">
+                        <div class="exercise-number">1</div>
+                        <div class="exercise-info">
+                            <div class="exercise-info-name">혀 올리기</div>
+                            <div class="exercise-info-detail">5초 유지 × 10회</div>
+                        </div>
+                    </div>
+                    <div class="exercise-item">
+                        <div class="exercise-number">2</div>
+                        <div class="exercise-info">
+                            <div class="exercise-info-name">혀 내밀기</div>
+                            <div class="exercise-info-detail">3초 유지 × 10회</div>
+                        </div>
+                    </div>
+                    <div class="exercise-item">
+                        <div class="exercise-number">3</div>
+                        <div class="exercise-info">
+                            <div class="exercise-info-name">혀 클릭</div>
+                            <div class="exercise-info-detail">15회</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <p style="color: var(--text-muted); margin-bottom: 20px; font-size: 0.95rem;">
+                약 8분 소요 • 눈 감고도 가능
+            </p>
+
+            <button class="btn btn-primary" id="startBtn">
+                ▶ 시작하기
+            </button>
+        </div>
+
+        <!-- 훈련 화면 -->
+        <div class="training-screen" id="trainingScreen">
+            <div class="header">
+                <h1 class="title" id="currentExerciseTitle">혀 올리기</h1>
+            </div>
+
+            <div class="animation-area">
+                <div class="mouth-container">
+                    <div class="mouth" id="mouth">
+                        <div class="palate"></div>
+                        <div class="tongue" id="tongue"></div>
+                    </div>
+                </div>
+
+                <div class="exercise-name" id="exerciseStatus">준비</div>
+                <div class="exercise-instruction" id="instruction">
+                    혀를 입천장에 붙이고 5초 유지하세요
+                </div>
+            </div>
+
+            <div class="timer-section">
+                <div class="timer-display" id="timerDisplay">5</div>
+
+                <div class="progress-container">
+                    <div class="progress-bar" id="progressBar" style="width: 0%"></div>
+                </div>
+                <div class="progress-text" id="progressText">운동 1/3 • 반복 1/10</div>
+            </div>
+
+            <div class="rep-counter" id="repCounter">
+                <!-- 반복 도트들이 여기에 들어감 -->
+            </div>
+
+            <button class="btn btn-success" id="successBtn">
+                ✔ 완료
+            </button>
+        </div>
+
+        <!-- 완료 화면 -->
+        <div class="complete-screen" id="completeScreen">
+            <div class="complete-icon">🎉</div>
+            <h2 class="complete-title">훈련 완료!</h2>
+            <p class="complete-stats" id="completeStats">
+                오늘도 잘 했어요!<br>
+                총 소요 시간: <span id="totalTime">8분 30초</span>
+            </p>
+            <button class="btn btn-primary" id="restartBtn">
+                다시 하기
+            </button>
+        </div>
+    </div>
+
+    <!-- 카운트다운 오버레이 -->
+    <div class="countdown-overlay" id="countdownOverlay">
+        <div class="countdown-number" id="countdownNumber">3</div>
+    </div>
+
+    <script>
+        // ==================== 설정 ====================
+        const ROUTINE = [
+            {
+                name: "혀 올리기",
+                hold: 5,
+                reps: 10,
+                rest: 2,
+                instruction: "혀 전체를 입천장에 붙이고\n유지하세요",
+                animation: "up"
+            },
+            {
+                name: "혀 내밀기",
+                hold: 3,
+                reps: 10,
+                rest: 2,
+                instruction: "혀를 최대한 앞으로 내밀고\n유지하세요",
+                animation: "out"
+            },
+            {
+                name: "혀 클릭",
+                hold: 0,
+                reps: 15,
+                rest: 1,
+                instruction: "혀를 입천장에 붙였다\n'똑' 소리내며 떼세요",
+                animation: "click"
+            }
+        ];
+
+        // ==================== 상태 ====================
+        let state = {
+            currentExercise: 0,
+            currentRep: 0,
+            isHolding: false,
+            isResting: false,
+            timerValue: 0,
+            timerInterval: null,
+            voiceEnabled: true,
+            startTime: null,
+            isPaused: false
+        };
+
+        // ==================== DOM 요소 ====================
+        const elements = {
+            startScreen: document.getElementById('startScreen'),
+            trainingScreen: document.getElementById('trainingScreen'),
+            completeScreen: document.getElementById('completeScreen'),
+            countdownOverlay: document.getElementById('countdownOverlay'),
+            countdownNumber: document.getElementById('countdownNumber'),
+            startBtn: document.getElementById('startBtn'),
+            successBtn: document.getElementById('successBtn'),
+            restartBtn: document.getElementById('restartBtn'),
+            voiceToggle: document.getElementById('voiceToggle'),
+            currentExerciseTitle: document.getElementById('currentExerciseTitle'),
+            exerciseStatus: document.getElementById('exerciseStatus'),
+            instruction: document.getElementById('instruction'),
+            timerDisplay: document.getElementById('timerDisplay'),
+            progressBar: document.getElementById('progressBar'),
+            progressText: document.getElementById('progressText'),
+            repCounter: document.getElementById('repCounter'),
+            mouth: document.getElementById('mouth'),
+            tongue: document.getElementById('tongue'),
+            streakCount: document.getElementById('streakCount'),
+            totalTime: document.getElementById('totalTime')
+        };
+
+        // ==================== 음성 합성 ====================
+        function speak(text) {
+            if (!state.voiceEnabled) return;
+
+            // 기존 음성 중지
+            window.speechSynthesis.cancel();
+
+            const utterance = new SpeechSynthesisUtterance(text);
+            utterance.lang = 'ko-KR';
+            utterance.rate = 1.0;
+            utterance.pitch = 1.0;
+
+            // 한국어 음성 찾기
+            const voices = window.speechSynthesis.getVoices();
+            const koreanVoice = voices.find(v => v.lang.includes('ko'));
+            if (koreanVoice) {
+                utterance.voice = koreanVoice;
+            }
+
+            window.speechSynthesis.speak(utterance);
+        }
+
+        // 음성 목록 로드 대기
+        window.speechSynthesis.onvoiceschanged = () => {
+            window.speechSynthesis.getVoices();
+        };
+
+        // ==================== 연속일 관리 ====================
+        function loadStreak() {
+            const data = JSON.parse(localStorage.getItem('tongueTraining') || '{}');
+            const today = new Date().toDateString();
+            const yesterday = new Date(Date.now() - 86400000).toDateString();
+
+            if (data.lastDate === today) {
+                // 오늘 이미 했음
+                return data.streak || 1;
+            } else if (data.lastDate === yesterday) {
+                // 어제 했음 - 연속 유지
+                return data.streak || 1;
+            } else {
+                // 연속 끊김
+                return 0;
+            }
+        }
+
+        function saveStreak() {
+            const data = JSON.parse(localStorage.getItem('tongueTraining') || '{}');
+            const today = new Date().toDateString();
+            const yesterday = new Date(Date.now() - 86400000).toDateString();
+
+            let newStreak = 1;
+            if (data.lastDate === yesterday) {
+                newStreak = (data.streak || 0) + 1;
+            } else if (data.lastDate === today) {
+                newStreak = data.streak || 1;
+            }
+
+            localStorage.setItem('tongueTraining', JSON.stringify({
+                lastDate: today,
+                streak: newStreak
+            }));
+
+            return newStreak;
+        }
+
+        // ==================== UI 업데이트 ====================
+        function updateRepDots(exercise, currentRep) {
+            const container = elements.repCounter;
+            container.innerHTML = '';
+
+            for (let i = 0; i < exercise.reps; i++) {
+                const dot = document.createElement('div');
+                dot.className = 'rep-dot';
+                if (i < currentRep) {
+                    dot.classList.add('completed');
+                } else if (i === currentRep) {
+                    dot.classList.add('current');
+                }
+                container.appendChild(dot);
+            }
+        }
+
+        function updateProgress() {
+            const exercise = ROUTINE[state.currentExercise];
+            const totalReps = ROUTINE.reduce((sum, e) => sum + e.reps, 0);
+            const completedReps = ROUTINE.slice(0, state.currentExercise).reduce((sum, e) => sum + e.reps, 0) + state.currentRep;
+            const progress = (completedReps / totalReps) * 100;
+
+            elements.progressBar.style.width = `${progress}%`;
+            elements.progressText.textContent = `운동 ${state.currentExercise + 1}/3 • 반복 ${state.currentRep + 1}/${exercise.reps}`;
+        }
+
+        function setTongueAnimation(type) {
+            elements.tongue.classList.remove('up', 'out', 'click');
+            elements.mouth.classList.remove('open');
+
+            if (type === 'up') {
+                elements.mouth.classList.add('open');
+                elements.tongue.classList.add('up');
+            } else if (type === 'out') {
+                elements.mouth.classList.add('open');
+                elements.tongue.classList.add('out');
+            } else if (type === 'click') {
+                elements.mouth.classList.add('open');
+                elements.tongue.classList.add('click');
+            }
+        }
+
+        // ==================== 타이머 로직 ====================
+        function startHoldTimer(seconds, onComplete) {
+            state.timerValue = seconds;
+            state.isHolding = true;
+
+            elements.timerDisplay.textContent = seconds;
+            elements.timerDisplay.classList.add('counting');
+            elements.timerDisplay.classList.remove('rest');
+
+            clearInterval(state.timerInterval);
+            state.timerInterval = setInterval(() => {
+                state.timerValue--;
+                elements.timerDisplay.textContent = state.timerValue;
+
+                // 카운트다운 음성
+                if (state.timerValue <= 3 && state.timerValue > 0) {
+                    speak(state.timerValue.toString());
+                }
+
+                if (state.timerValue <= 0) {
+                    clearInterval(state.timerInterval);
+                    state.isHolding = false;
+                    onComplete();
+                }
+            }, 1000);
+        }
+
+        function startRestTimer(seconds, onComplete) {
+            state.timerValue = seconds;
+            state.isResting = true;
+
+            elements.exerciseStatus.textContent = '쉬기';
+            elements.timerDisplay.textContent = seconds;
+            elements.timerDisplay.classList.remove('counting');
+            elements.timerDisplay.classList.add('rest');
+            setTongueAnimation(null);
+
+            speak('쉬세요');
+
+            clearInterval(state.timerInterval);
+            state.timerInterval = setInterval(() => {
+                state.timerValue--;
+                elements.timerDisplay.textContent = state.timerValue;
+
+                if (state.timerValue <= 0) {
+                    clearInterval(state.timerInterval);
+                    state.isResting = false;
+                    onComplete();
+                }
+            }, 1000);
+        }
+
+        // ==================== 운동 로직 ====================
+        function startExercise() {
+            const exercise = ROUTINE[state.currentExercise];
+
+            elements.currentExerciseTitle.textContent = exercise.name;
+            elements.instruction.textContent = exercise.instruction;
+            updateRepDots(exercise, state.currentRep);
+            updateProgress();
+
+            speak(`${exercise.name} 시작`);
+
+            setTimeout(() => {
+                doRep();
+            }, 1500);
+        }
+
+        function doRep() {
+            const exercise = ROUTINE[state.currentExercise];
+
+            if (state.currentRep >= exercise.reps) {
+                // 이 운동 완료
+                nextExercise();
+                return;
+            }
+
+            updateRepDots(exercise, state.currentRep);
+            updateProgress();
+
+            if (exercise.hold > 0) {
+                // 유지 운동 (혀 올리기, 내밀기)
+                elements.exerciseStatus.textContent = '유지';
+                setTongueAnimation(exercise.animation);
+                speak(exercise.instruction.split('\n')[0]);
+
+                elements.successBtn.classList.add('hidden');
+
+                startHoldTimer(exercise.hold, () => {
+                    speak('좋아요');
+                    state.currentRep++;
+
+                    if (state.currentRep < exercise.reps) {
+                        startRestTimer(exercise.rest, doRep);
+                    } else {
+                        setTimeout(() => nextExercise(), 500);
+                    }
+                });
+            } else {
+                // 클릭 운동
+                elements.exerciseStatus.textContent = '클릭!';
+                elements.timerDisplay.textContent = `${state.currentRep + 1}`;
+                elements.timerDisplay.classList.remove('counting', 'rest');
+
+                speak('클릭');
+                setTongueAnimation('click');
+
+                // 성공 버튼 표시
+                elements.successBtn.classList.remove('hidden');
+            }
+        }
+
+        function handleSuccessClick() {
+            const exercise = ROUTINE[state.currentExercise];
+
+            if (exercise.hold === 0) {
+                // 클릭 운동 - 성공 버튼으로 진행
+                setTongueAnimation('click');
+                state.currentRep++;
+
+                if (state.currentRep < exercise.reps) {
+                    updateRepDots(exercise, state.currentRep);
+                    updateProgress();
+                    elements.timerDisplay.textContent = `${state.currentRep + 1}`;
+
+                    setTimeout(() => {
+                        speak('클릭');
+                        setTongueAnimation('click');
+                    }, exercise.rest * 1000);
+                } else {
+                    elements.successBtn.classList.add('hidden');
+                    nextExercise();
+                }
+            }
+        }
+
+        function nextExercise() {
+            state.currentExercise++;
+            state.currentRep = 0;
+
+            if (state.currentExercise >= ROUTINE.length) {
+                completeTraining();
+            } else {
+                const nextEx = ROUTINE[state.currentExercise];
+                speak(`다음 운동, ${nextEx.name}`);
+
+                setTimeout(() => {
+                    startExercise();
+                }, 2000);
+            }
+        }
+
+        // ==================== 시작/완료 ====================
+        function showCountdown(callback) {
+            elements.countdownOverlay.classList.add('show');
+            let count = 3;
+
+            function tick() {
+                elements.countdownNumber.textContent = count;
+                elements.countdownNumber.style.animation = 'none';
+                elements.countdownNumber.offsetHeight; // 리플로우
+                elements.countdownNumber.style.animation = 'countdownPop 1s ease';
+
+                speak(count.toString());
+
+                if (count > 1) {
+                    count--;
+                    setTimeout(tick, 1000);
+                } else {
+                    setTimeout(() => {
+                        elements.countdownOverlay.classList.remove('show');
+                        speak('시작!');
+                        callback();
+                    }, 1000);
+                }
+            }
+
+            tick();
+        }
+
+        function startTraining() {
+            state.currentExercise = 0;
+            state.currentRep = 0;
+            state.startTime = Date.now();
+
+            elements.startScreen.classList.add('hidden');
+            elements.completeScreen.classList.remove('show');
+            elements.trainingScreen.classList.add('show');
+
+            showCountdown(() => {
+                startExercise();
+            });
+        }
+
+        function completeTraining() {
+            clearInterval(state.timerInterval);
+
+            const elapsed = Math.floor((Date.now() - state.startTime) / 1000);
+            const minutes = Math.floor(elapsed / 60);
+            const seconds = elapsed % 60;
+
+            elements.totalTime.textContent = `${minutes}분 ${seconds}초`;
+
+            const newStreak = saveStreak();
+            elements.streakCount.textContent = newStreak;
+
+            elements.trainingScreen.classList.remove('show');
+            elements.completeScreen.classList.add('show');
+
+            speak('훈련 완료! 잘 했어요!');
+        }
+
+        function resetTraining() {
+            clearInterval(state.timerInterval);
+
+            state.currentExercise = 0;
+            state.currentRep = 0;
+            state.isHolding = false;
+            state.isResting = false;
+
+            elements.completeScreen.classList.remove('show');
+            elements.trainingScreen.classList.remove('show');
+            elements.startScreen.classList.remove('hidden');
+
+            setTongueAnimation(null);
+        }
+
+        // ==================== 이벤트 리스너 ====================
+        elements.startBtn.addEventListener('click', startTraining);
+        elements.successBtn.addEventListener('click', handleSuccessClick);
+        elements.restartBtn.addEventListener('click', resetTraining);
+
+        elements.voiceToggle.addEventListener('click', () => {
+            state.voiceEnabled = !state.voiceEnabled;
+            elements.voiceToggle.textContent = state.voiceEnabled ? '🔊' : '🔇';
+
+            if (!state.voiceEnabled) {
+                window.speechSynthesis.cancel();
+            }
+        });
+
+        // ==================== 초기화 ====================
+        function init() {
+            const streak = loadStreak();
+            elements.streakCount.textContent = streak;
+
+            // 음성 엔진 준비
+            window.speechSynthesis.getVoices();
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/tongue-training.html
+++ b/tongue-training.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>혀 훈련</title>
+
+    <!-- PWA Meta Tags -->
+    <meta name="description" content="8주 혀 근력 강화 프로그램 - 수면무호흡 개선을 위한 과학적 훈련">
+    <meta name="theme-color" content="#0a0a0f">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="혀 훈련">
+    <link rel="manifest" href="manifest.json">
+    <link rel="apple-touch-icon" href="icons/icon.svg">
+
     <!-- Spline 3D Runtime -->
     <script type="module" src="https://unpkg.com/@splinetool/viewer@1.9.82/build/spline-viewer.js"></script>
     <style>
@@ -1175,6 +1185,91 @@
                 height: 130px;
             }
         }
+
+        /* PWA 설치 배너 */
+        .install-banner {
+            position: fixed;
+            bottom: -100px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: calc(100% - 32px);
+            max-width: 400px;
+            padding: 16px 20px;
+            border-radius: 20px;
+            background: rgba(99, 102, 241, 0.15);
+            border: 1px solid rgba(99, 102, 241, 0.3);
+            backdrop-filter: blur(20px);
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            z-index: 1000;
+            transition: bottom 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+        }
+
+        .install-banner.show {
+            bottom: 24px;
+        }
+
+        .install-banner .install-icon {
+            font-size: 2rem;
+            flex-shrink: 0;
+        }
+
+        .install-banner .install-text {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .install-banner .install-text strong {
+            display: block;
+            font-size: 0.9rem;
+            margin-bottom: 2px;
+        }
+
+        .install-banner .install-text span {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+        }
+
+        .install-banner .btn-install {
+            padding: 10px 16px;
+            border-radius: 12px;
+            border: none;
+            background: linear-gradient(135deg, var(--accent-1), var(--accent-2));
+            color: white;
+            font-size: 0.8rem;
+            font-weight: 600;
+            font-family: inherit;
+            cursor: pointer;
+            flex-shrink: 0;
+            transition: transform 0.2s;
+        }
+
+        .install-banner .btn-install:active {
+            transform: scale(0.95);
+        }
+
+        .install-banner .btn-dismiss {
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            border: none;
+            background: rgba(255,255,255,0.1);
+            color: var(--text-secondary);
+            font-size: 1rem;
+            cursor: pointer;
+            flex-shrink: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        /* PWA 상태 표시 (standalone 모드) */
+        @media (display-mode: standalone) {
+            .controls {
+                padding-top: env(safe-area-inset-top, 12px);
+            }
+        }
     </style>
 </head>
 <body>
@@ -1183,6 +1278,17 @@
         <div class="orb orb-1"></div>
         <div class="orb orb-2"></div>
         <div class="orb orb-3"></div>
+    </div>
+
+    <!-- PWA 설치 배너 -->
+    <div id="installBanner" class="install-banner">
+        <div class="install-icon">📲</div>
+        <div class="install-text">
+            <strong>홈 화면에 추가</strong>
+            <span>더 빠르게 훈련을 시작하세요</span>
+        </div>
+        <button id="btnInstall" class="btn-install">설치</button>
+        <button id="btnDismiss" class="btn-dismiss">&times;</button>
     </div>
 
     <!-- 컨트롤 -->
@@ -2351,11 +2457,106 @@
             }
         }
 
+        // ========== PWA ==========
+        let deferredPrompt = null;
+
+        // Service Worker 등록
+        async function registerServiceWorker() {
+            if ('serviceWorker' in navigator) {
+                try {
+                    const registration = await navigator.serviceWorker.register('/sw.js', {
+                        scope: '/'
+                    });
+                    console.log('Service Worker 등록 성공:', registration.scope);
+
+                    // 업데이트 확인
+                    registration.addEventListener('updatefound', () => {
+                        const newWorker = registration.installing;
+                        newWorker.addEventListener('statechange', () => {
+                            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                                console.log('새 버전 사용 가능');
+                            }
+                        });
+                    });
+                } catch (error) {
+                    console.warn('Service Worker 등록 실패:', error);
+                }
+            }
+        }
+
+        // 설치 프롬프트 처리
+        function initInstallPrompt() {
+            const banner = document.getElementById('installBanner');
+            const btnInstall = document.getElementById('btnInstall');
+            const btnDismiss = document.getElementById('btnDismiss');
+
+            // 이미 설치된 경우 (standalone 모드)
+            if (window.matchMedia('(display-mode: standalone)').matches) {
+                console.log('PWA로 실행 중');
+                return;
+            }
+
+            // 설치 프롬프트 이벤트 캡처
+            window.addEventListener('beforeinstallprompt', (e) => {
+                e.preventDefault();
+                deferredPrompt = e;
+                console.log('설치 프롬프트 준비됨');
+
+                // 연속 3일 이상 사용 시에만 배너 표시
+                const streak = loadStreak();
+                const dismissed = localStorage.getItem('installDismissed');
+                const dismissedDate = dismissed ? new Date(dismissed) : null;
+                const now = new Date();
+
+                // 7일 이내에 dismiss 한 경우 표시하지 않음
+                if (dismissedDate && (now - dismissedDate) < 7 * 24 * 60 * 60 * 1000) {
+                    return;
+                }
+
+                if (streak >= 3) {
+                    setTimeout(() => {
+                        banner.classList.add('show');
+                    }, 2000);
+                }
+            });
+
+            // 설치 버튼 클릭
+            btnInstall.addEventListener('click', async () => {
+                if (!deferredPrompt) return;
+
+                deferredPrompt.prompt();
+                const { outcome } = await deferredPrompt.userChoice;
+
+                console.log('설치 결과:', outcome);
+                deferredPrompt = null;
+                banner.classList.remove('show');
+
+                if (outcome === 'accepted') {
+                    localStorage.setItem('pwaInstalled', 'true');
+                }
+            });
+
+            // 닫기 버튼 클릭
+            btnDismiss.addEventListener('click', () => {
+                banner.classList.remove('show');
+                localStorage.setItem('installDismissed', new Date().toISOString());
+            });
+
+            // 앱 설치 완료 이벤트
+            window.addEventListener('appinstalled', () => {
+                console.log('PWA 설치 완료');
+                banner.classList.remove('show');
+                deferredPrompt = null;
+            });
+        }
+
         // ========== 초기화 ==========
         function init() {
             el.streakCount.textContent = loadStreak();
             window.speechSynthesis.getVoices();
             initSpline();
+            registerServiceWorker();
+            initInstallPrompt();
         }
 
         init();

--- a/tongue-training.html
+++ b/tongue-training.html
@@ -640,6 +640,366 @@
             display: none;
         }
 
+        /* ========== 대시보드 화면 ========== */
+        .dashboard-screen {
+            display: none;
+            text-align: center;
+            max-width: 420px;
+        }
+
+        .dashboard-screen.show {
+            display: block;
+            animation: fadeIn 0.4s ease;
+        }
+
+        .dashboard-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 24px;
+        }
+
+        .dashboard-title {
+            font-size: 1.25rem;
+            font-weight: 500;
+        }
+
+        .btn-close {
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            border: 1px solid var(--glass-border);
+            background: transparent;
+            color: var(--text-secondary);
+            font-size: 1.2rem;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .btn-close:hover {
+            background: rgba(255,255,255,0.1);
+            color: var(--text-primary);
+        }
+
+        /* 통계 카드 */
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 12px;
+            margin-bottom: 24px;
+        }
+
+        .stat-card {
+            background: rgba(255,255,255,0.02);
+            border: 1px solid rgba(255,255,255,0.05);
+            border-radius: 16px;
+            padding: 16px;
+            text-align: center;
+        }
+
+        .stat-card .value {
+            font-size: 1.75rem;
+            font-weight: 600;
+            background: linear-gradient(135deg, var(--accent-1), var(--accent-2));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .stat-card .label {
+            font-size: 0.7rem;
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-top: 4px;
+        }
+
+        /* 히트맵 */
+        .heatmap-section {
+            margin-bottom: 24px;
+        }
+
+        .section-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+
+        .section-title {
+            font-size: 0.85rem;
+            font-weight: 500;
+            color: var(--text-secondary);
+        }
+
+        .section-subtitle {
+            font-size: 0.7rem;
+            color: var(--text-tertiary);
+        }
+
+        .heatmap-container {
+            background: rgba(0,0,0,0.2);
+            border-radius: 12px;
+            padding: 16px;
+            overflow-x: auto;
+        }
+
+        .heatmap-months {
+            display: flex;
+            gap: 2px;
+            font-size: 0.65rem;
+            color: var(--text-tertiary);
+            margin-bottom: 4px;
+            padding-left: 20px;
+        }
+
+        .heatmap-months span {
+            width: 36px;
+            text-align: center;
+        }
+
+        .heatmap-grid {
+            display: flex;
+            gap: 2px;
+        }
+
+        .heatmap-days {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            font-size: 0.6rem;
+            color: var(--text-tertiary);
+            margin-right: 4px;
+        }
+
+        .heatmap-days span {
+            height: 10px;
+            line-height: 10px;
+        }
+
+        .heatmap-weeks {
+            display: flex;
+            gap: 2px;
+        }
+
+        .heatmap-week {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+
+        .heatmap-cell {
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+            background: rgba(255,255,255,0.05);
+        }
+
+        .heatmap-cell.level-1 { background: rgba(99, 102, 241, 0.3); }
+        .heatmap-cell.level-2 { background: rgba(99, 102, 241, 0.5); }
+        .heatmap-cell.level-3 { background: rgba(99, 102, 241, 0.7); }
+        .heatmap-cell.level-4 { background: rgba(99, 102, 241, 1); }
+
+        .heatmap-legend {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 4px;
+            margin-top: 8px;
+            font-size: 0.6rem;
+            color: var(--text-tertiary);
+        }
+
+        .heatmap-legend .cell {
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+        }
+
+        /* 주간 차트 */
+        .chart-section {
+            margin-bottom: 24px;
+        }
+
+        .weekly-chart {
+            background: rgba(0,0,0,0.2);
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        .chart-bars {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            height: 100px;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .chart-bar-wrapper {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            height: 100%;
+        }
+
+        .chart-bar {
+            width: 100%;
+            max-width: 24px;
+            background: linear-gradient(180deg, var(--accent-1), var(--accent-2));
+            border-radius: 4px 4px 0 0;
+            transition: height 0.5s ease;
+            position: relative;
+        }
+
+        .chart-bar.today {
+            background: linear-gradient(180deg, var(--accent-3), var(--accent-2));
+        }
+
+        .chart-bar-value {
+            position: absolute;
+            top: -18px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: 0.65rem;
+            color: var(--text-secondary);
+            white-space: nowrap;
+        }
+
+        .chart-labels {
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .chart-label {
+            flex: 1;
+            text-align: center;
+            font-size: 0.7rem;
+            color: var(--text-tertiary);
+        }
+
+        .chart-label.today {
+            color: var(--accent-3);
+            font-weight: 500;
+        }
+
+        /* 수면 입력 */
+        .sleep-section {
+            margin-bottom: 24px;
+        }
+
+        .sleep-input-row {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .sleep-input-group {
+            flex: 1;
+            background: rgba(0,0,0,0.2);
+            border-radius: 12px;
+            padding: 12px;
+            text-align: center;
+        }
+
+        .sleep-input-label {
+            font-size: 0.7rem;
+            color: var(--text-tertiary);
+            margin-bottom: 6px;
+        }
+
+        .sleep-input {
+            width: 100%;
+            background: transparent;
+            border: none;
+            color: var(--text-primary);
+            font-size: 1.25rem;
+            font-family: inherit;
+            text-align: center;
+            outline: none;
+        }
+
+        .sleep-input::placeholder {
+            color: var(--text-tertiary);
+        }
+
+        .sleep-quality {
+            display: flex;
+            justify-content: center;
+            gap: 8px;
+            margin-top: 12px;
+        }
+
+        .quality-btn {
+            padding: 8px 16px;
+            border-radius: 20px;
+            border: 1px solid rgba(255,255,255,0.1);
+            background: transparent;
+            color: var(--text-tertiary);
+            font-size: 0.75rem;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .quality-btn:hover {
+            border-color: var(--accent-1);
+            color: var(--text-secondary);
+        }
+
+        .quality-btn.active {
+            background: var(--accent-1);
+            border-color: var(--accent-1);
+            color: white;
+        }
+
+        /* 상관관계 인사이트 */
+        .insight-card {
+            background: linear-gradient(135deg, rgba(99,102,241,0.1), rgba(236,72,153,0.1));
+            border: 1px solid rgba(99,102,241,0.2);
+            border-radius: 16px;
+            padding: 16px;
+            text-align: left;
+        }
+
+        .insight-icon {
+            font-size: 1.5rem;
+            margin-bottom: 8px;
+        }
+
+        .insight-text {
+            font-size: 0.85rem;
+            color: var(--text-secondary);
+            line-height: 1.5;
+        }
+
+        .insight-highlight {
+            color: var(--accent-1);
+            font-weight: 500;
+        }
+
+        /* 대시보드 버튼 */
+        .btn-dashboard {
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            border: 1px solid var(--glass-border);
+            background: var(--glass);
+            backdrop-filter: blur(20px);
+            color: var(--text-secondary);
+            font-size: 1.1rem;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .btn-dashboard:hover {
+            background: rgba(255, 255, 255, 0.1);
+            color: var(--text-primary);
+        }
+
         /* 반응형 */
         @media (max-width: 420px) {
             .glass-card {
@@ -673,6 +1033,7 @@
 
     <!-- 컨트롤 -->
     <div class="controls">
+        <button class="control-btn btn-dashboard" id="dashboardBtn" title="통계">📊</button>
         <button class="control-btn" id="voiceToggle" title="음성">🔊</button>
     </div>
 
@@ -843,6 +1204,108 @@
 
             <button class="btn-restart" id="restartBtn">다시 하기</button>
         </div>
+
+        <!-- ========== 대시보드 화면 ========== -->
+        <div class="glass-card dashboard-screen" id="dashboardScreen">
+            <div class="dashboard-header">
+                <h2 class="dashboard-title">나의 훈련 기록</h2>
+                <button class="btn-close" id="closeDashboard">&times;</button>
+            </div>
+
+            <!-- 통계 카드 -->
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="value" id="statTotalDays">0</div>
+                    <div class="label">총 훈련일</div>
+                </div>
+                <div class="stat-card">
+                    <div class="value" id="statTotalReps">0</div>
+                    <div class="label">총 반복</div>
+                </div>
+                <div class="stat-card">
+                    <div class="value" id="statTotalTime">0분</div>
+                    <div class="label">총 시간</div>
+                </div>
+                <div class="stat-card">
+                    <div class="value" id="statMaxStreak">0</div>
+                    <div class="label">최장 연속</div>
+                </div>
+            </div>
+
+            <!-- 히트맵 -->
+            <div class="heatmap-section">
+                <div class="section-header">
+                    <span class="section-title">연간 훈련 현황</span>
+                    <span class="section-subtitle" id="heatmapYear">2026</span>
+                </div>
+                <div class="heatmap-container">
+                    <div class="heatmap-months" id="heatmapMonths"></div>
+                    <div class="heatmap-grid">
+                        <div class="heatmap-days">
+                            <span>월</span>
+                            <span></span>
+                            <span>수</span>
+                            <span></span>
+                            <span>금</span>
+                            <span></span>
+                            <span>일</span>
+                        </div>
+                        <div class="heatmap-weeks" id="heatmapWeeks"></div>
+                    </div>
+                    <div class="heatmap-legend">
+                        <span>Less</span>
+                        <div class="cell" style="background: rgba(255,255,255,0.05)"></div>
+                        <div class="cell" style="background: rgba(99,102,241,0.3)"></div>
+                        <div class="cell" style="background: rgba(99,102,241,0.5)"></div>
+                        <div class="cell" style="background: rgba(99,102,241,0.7)"></div>
+                        <div class="cell" style="background: rgba(99,102,241,1)"></div>
+                        <span>More</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 주간 차트 -->
+            <div class="chart-section">
+                <div class="section-header">
+                    <span class="section-title">이번 주 훈련</span>
+                    <span class="section-subtitle" id="weekRange"></span>
+                </div>
+                <div class="weekly-chart">
+                    <div class="chart-bars" id="chartBars"></div>
+                    <div class="chart-labels" id="chartLabels"></div>
+                </div>
+            </div>
+
+            <!-- 수면 입력 -->
+            <div class="sleep-section">
+                <div class="section-header">
+                    <span class="section-title">오늘의 수면</span>
+                    <span class="section-subtitle">Galaxy Watch 연동 예정</span>
+                </div>
+                <div class="sleep-input-row">
+                    <div class="sleep-input-group">
+                        <div class="sleep-input-label">수면 시간</div>
+                        <input type="text" class="sleep-input" id="sleepHours" placeholder="7시간 30분" />
+                    </div>
+                </div>
+                <div class="sleep-quality">
+                    <button class="quality-btn" data-quality="bad">😫 나쁨</button>
+                    <button class="quality-btn" data-quality="ok">😐 보통</button>
+                    <button class="quality-btn" data-quality="good">😊 좋음</button>
+                    <button class="quality-btn" data-quality="great">🤩 최고</button>
+                </div>
+            </div>
+
+            <!-- 인사이트 -->
+            <div class="insight-card" id="insightCard">
+                <div class="insight-icon">💡</div>
+                <div class="insight-text">
+                    <span class="insight-highlight">7시간 이상</span> 수면 후 훈련 완주율이
+                    <span class="insight-highlight">23% 높아요</span>.
+                    충분히 자고 훈련해보세요!
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- 카운트다운 -->
@@ -902,7 +1365,23 @@
             splineViewer: $('splineViewer'),
             splineContainer: $('splineContainer'),
             splineLoading: $('splineLoading'),
-            mouthSvgFallback: $('mouthSvgFallback')
+            mouthSvgFallback: $('mouthSvgFallback'),
+            // 대시보드
+            dashboardBtn: $('dashboardBtn'),
+            dashboardScreen: $('dashboardScreen'),
+            closeDashboard: $('closeDashboard'),
+            statTotalDays: $('statTotalDays'),
+            statTotalReps: $('statTotalReps'),
+            statTotalTime: $('statTotalTime'),
+            statMaxStreak: $('statMaxStreak'),
+            heatmapWeeks: $('heatmapWeeks'),
+            heatmapMonths: $('heatmapMonths'),
+            heatmapYear: $('heatmapYear'),
+            chartBars: $('chartBars'),
+            chartLabels: $('chartLabels'),
+            weekRange: $('weekRange'),
+            sleepHours: $('sleepHours'),
+            insightCard: $('insightCard')
         };
 
         // ========== 음성 ==========
@@ -943,6 +1422,290 @@
             }
             localStorage.setItem('tongueTraining', JSON.stringify({ lastDate: today, streak: newStreak }));
             return newStreak;
+        }
+
+        // ========== 세션 히스토리 ==========
+        function getHistory() {
+            return JSON.parse(localStorage.getItem('tongueHistory') || '[]');
+        }
+
+        function saveSession(duration, reps) {
+            const history = getHistory();
+            const today = new Date().toISOString().split('T')[0];
+            const session = {
+                date: today,
+                timestamp: Date.now(),
+                duration: duration,  // 초
+                reps: reps,
+                sleep: getTodaySleep()
+            };
+            history.push(session);
+            localStorage.setItem('tongueHistory', JSON.stringify(history));
+        }
+
+        function getTodaySleep() {
+            const data = JSON.parse(localStorage.getItem('tongueSleep') || '{}');
+            const today = new Date().toISOString().split('T')[0];
+            return data[today] || null;
+        }
+
+        function saveSleep(hours, quality) {
+            const data = JSON.parse(localStorage.getItem('tongueSleep') || '{}');
+            const today = new Date().toISOString().split('T')[0];
+            data[today] = { hours, quality };
+            localStorage.setItem('tongueSleep', JSON.stringify(data));
+        }
+
+        // ========== 대시보드 ==========
+        function openDashboard() {
+            el.startScreen.classList.add('hidden');
+            el.trainingScreen.classList.remove('show');
+            el.completeScreen.classList.remove('show');
+            el.dashboardScreen.classList.add('show');
+            renderDashboard();
+        }
+
+        function closeDashboard() {
+            el.dashboardScreen.classList.remove('show');
+            el.startScreen.classList.remove('hidden');
+        }
+
+        function renderDashboard() {
+            const history = getHistory();
+            renderStats(history);
+            renderHeatmap(history);
+            renderWeeklyChart(history);
+            renderSleepInput();
+            renderInsight(history);
+        }
+
+        function renderStats(history) {
+            // 고유 날짜 수
+            const uniqueDays = new Set(history.map(s => s.date)).size;
+            el.statTotalDays.textContent = uniqueDays;
+
+            // 총 반복
+            const totalReps = history.reduce((sum, s) => sum + (s.reps || 0), 0);
+            el.statTotalReps.textContent = totalReps;
+
+            // 총 시간 (분)
+            const totalSec = history.reduce((sum, s) => sum + (s.duration || 0), 0);
+            const totalMin = Math.round(totalSec / 60);
+            el.statTotalTime.textContent = totalMin + '분';
+
+            // 최장 연속
+            const dates = [...new Set(history.map(s => s.date))].sort();
+            let maxStreak = 0, currentStreak = 0, prevDate = null;
+            for (const dateStr of dates) {
+                const d = new Date(dateStr);
+                if (prevDate) {
+                    const diff = (d - prevDate) / (1000 * 60 * 60 * 24);
+                    if (diff === 1) {
+                        currentStreak++;
+                    } else {
+                        currentStreak = 1;
+                    }
+                } else {
+                    currentStreak = 1;
+                }
+                maxStreak = Math.max(maxStreak, currentStreak);
+                prevDate = d;
+            }
+            el.statMaxStreak.textContent = maxStreak;
+        }
+
+        function renderHeatmap(history) {
+            const today = new Date();
+            el.heatmapYear.textContent = today.getFullYear();
+
+            // 날짜별 세션 수 집계
+            const dayCounts = {};
+            history.forEach(s => {
+                dayCounts[s.date] = (dayCounts[s.date] || 0) + 1;
+            });
+
+            // 52주 생성
+            const weeks = [];
+            const monthLabels = [];
+            let currentMonth = -1;
+
+            // 52주 전부터 오늘까지
+            const startDate = new Date(today);
+            startDate.setDate(startDate.getDate() - 364);
+            // 월요일로 맞추기
+            while (startDate.getDay() !== 1) {
+                startDate.setDate(startDate.getDate() - 1);
+            }
+
+            let weekEl = document.createElement('div');
+            weekEl.className = 'heatmap-week';
+
+            const current = new Date(startDate);
+            let weekCount = 0;
+
+            while (current <= today) {
+                const dateStr = current.toISOString().split('T')[0];
+                const count = dayCounts[dateStr] || 0;
+                const level = count === 0 ? 0 : count >= 3 ? 4 : count >= 2 ? 3 : count >= 1 ? 2 : 1;
+
+                const cell = document.createElement('div');
+                cell.className = `heatmap-cell level-${level}`;
+                cell.title = `${dateStr}: ${count}회`;
+                weekEl.appendChild(cell);
+
+                // 월 레이블
+                if (current.getMonth() !== currentMonth && current.getDate() <= 7) {
+                    monthLabels.push({ week: weekCount, month: current.toLocaleString('ko', { month: 'short' }) });
+                    currentMonth = current.getMonth();
+                }
+
+                current.setDate(current.getDate() + 1);
+
+                if (current.getDay() === 1) {
+                    weeks.push(weekEl);
+                    weekEl = document.createElement('div');
+                    weekEl.className = 'heatmap-week';
+                    weekCount++;
+                }
+            }
+
+            if (weekEl.children.length > 0) {
+                weeks.push(weekEl);
+            }
+
+            el.heatmapWeeks.innerHTML = '';
+            weeks.forEach(w => el.heatmapWeeks.appendChild(w));
+
+            // 월 레이블 렌더링
+            el.heatmapMonths.innerHTML = '';
+            const monthSpans = new Array(53).fill('');
+            monthLabels.forEach(m => {
+                if (m.week < monthSpans.length) monthSpans[m.week] = m.month;
+            });
+            // 간격 조절해서 일부만 표시
+            for (let i = 0; i < 53; i += 4) {
+                const span = document.createElement('span');
+                span.textContent = monthSpans[i] || '';
+                el.heatmapMonths.appendChild(span);
+            }
+        }
+
+        function renderWeeklyChart(history) {
+            const today = new Date();
+            const dayOfWeek = today.getDay() || 7; // 일요일=7
+            const monday = new Date(today);
+            monday.setDate(today.getDate() - dayOfWeek + 1);
+
+            const days = ['월', '화', '수', '목', '금', '토', '일'];
+            const weekData = [];
+
+            for (let i = 0; i < 7; i++) {
+                const d = new Date(monday);
+                d.setDate(monday.getDate() + i);
+                const dateStr = d.toISOString().split('T')[0];
+                const sessions = history.filter(s => s.date === dateStr);
+                const totalMin = Math.round(sessions.reduce((sum, s) => sum + (s.duration || 0), 0) / 60);
+                weekData.push({
+                    day: days[i],
+                    minutes: totalMin,
+                    isToday: dateStr === today.toISOString().split('T')[0]
+                });
+            }
+
+            const maxMin = Math.max(...weekData.map(d => d.minutes), 1);
+
+            el.chartBars.innerHTML = '';
+            el.chartLabels.innerHTML = '';
+
+            // 주간 범위 표시
+            const sunday = new Date(monday);
+            sunday.setDate(monday.getDate() + 6);
+            el.weekRange.textContent = `${monday.getMonth() + 1}/${monday.getDate()} - ${sunday.getMonth() + 1}/${sunday.getDate()}`;
+
+            weekData.forEach(d => {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'chart-bar-wrapper';
+
+                const bar = document.createElement('div');
+                bar.className = 'chart-bar' + (d.isToday ? ' today' : '');
+                const height = d.minutes > 0 ? Math.max((d.minutes / maxMin) * 80, 4) : 0;
+                bar.style.height = height + 'px';
+                bar.style.marginTop = 'auto';
+
+                if (d.minutes > 0) {
+                    const val = document.createElement('div');
+                    val.className = 'chart-bar-value';
+                    val.textContent = d.minutes + '분';
+                    bar.appendChild(val);
+                }
+
+                wrapper.appendChild(bar);
+                el.chartBars.appendChild(wrapper);
+
+                const label = document.createElement('div');
+                label.className = 'chart-label' + (d.isToday ? ' today' : '');
+                label.textContent = d.day;
+                el.chartLabels.appendChild(label);
+            });
+        }
+
+        function renderSleepInput() {
+            const sleepData = getTodaySleep();
+            if (sleepData) {
+                el.sleepHours.value = sleepData.hours || '';
+                document.querySelectorAll('.quality-btn').forEach(btn => {
+                    btn.classList.toggle('active', btn.dataset.quality === sleepData.quality);
+                });
+            }
+        }
+
+        function renderInsight(history) {
+            const sleepData = JSON.parse(localStorage.getItem('tongueSleep') || '{}');
+            const sessionsWithSleep = history.filter(s => {
+                const sleep = sleepData[s.date];
+                return sleep && sleep.hours;
+            });
+
+            if (sessionsWithSleep.length < 3) {
+                el.insightCard.querySelector('.insight-text').innerHTML = `
+                    수면 데이터를 <span class="insight-highlight">3일 이상</span> 기록하면
+                    <span class="insight-highlight">맞춤 인사이트</span>를 제공해드려요!
+                `;
+                return;
+            }
+
+            // 간단한 인사이트: 수면 시간별 훈련 완료율
+            let goodSleepDays = 0, goodSleepComplete = 0;
+            let badSleepDays = 0, badSleepComplete = 0;
+
+            sessionsWithSleep.forEach(s => {
+                const sleep = sleepData[s.date];
+                const hours = parseFloat(sleep.hours) || 0;
+                if (hours >= 7) {
+                    goodSleepDays++;
+                    if (s.reps >= TOTAL_REPS) goodSleepComplete++;
+                } else {
+                    badSleepDays++;
+                    if (s.reps >= TOTAL_REPS) badSleepComplete++;
+                }
+            });
+
+            const goodRate = goodSleepDays > 0 ? Math.round((goodSleepComplete / goodSleepDays) * 100) : 0;
+            const badRate = badSleepDays > 0 ? Math.round((badSleepComplete / badSleepDays) * 100) : 0;
+            const diff = goodRate - badRate;
+
+            if (diff > 0) {
+                el.insightCard.querySelector('.insight-text').innerHTML = `
+                    <span class="insight-highlight">7시간 이상</span> 수면 후 훈련 완주율이
+                    <span class="insight-highlight">${diff}% 높아요</span>.
+                    충분히 자고 훈련해보세요!
+                `;
+            } else {
+                el.insightCard.querySelector('.insight-text').innerHTML = `
+                    수면 시간과 관계없이 꾸준히 훈련 중이에요!
+                    <span class="insight-highlight">멋져요! 🎉</span>
+                `;
+            }
         }
 
         // ========== UI ==========
@@ -1166,6 +1929,9 @@
             el.newStreak.textContent = streak;
             el.streakCount.textContent = streak;
 
+            // 세션 히스토리 저장
+            saveSession(elapsed, TOTAL_REPS);
+
             el.trainingScreen.classList.remove('show');
             el.completeScreen.classList.add('show');
 
@@ -1194,6 +1960,24 @@
             state.voiceEnabled = !state.voiceEnabled;
             el.voiceToggle.textContent = state.voiceEnabled ? '🔊' : '🔇';
             if (!state.voiceEnabled) window.speechSynthesis.cancel();
+        });
+
+        // 대시보드
+        el.dashboardBtn.addEventListener('click', openDashboard);
+        el.closeDashboard.addEventListener('click', closeDashboard);
+
+        // 수면 입력
+        el.sleepHours.addEventListener('change', () => {
+            const quality = document.querySelector('.quality-btn.active')?.dataset.quality || 'ok';
+            saveSleep(el.sleepHours.value, quality);
+        });
+
+        document.querySelectorAll('.quality-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.quality-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                saveSleep(el.sleepHours.value || '', btn.dataset.quality);
+            });
         });
 
         // ========== Spline 초기화 ==========

--- a/tongue-training.html
+++ b/tongue-training.html
@@ -66,94 +66,74 @@
         .animation-area {
             background: var(--card);
             border-radius: 24px;
-            padding: 40px 20px;
+            padding: 30px 20px;
             margin-bottom: 20px;
             position: relative;
             overflow: hidden;
         }
 
         .mouth-container {
-            width: 200px;
-            height: 200px;
+            width: 280px;
+            height: 240px;
             margin: 0 auto 20px;
             position: relative;
         }
 
-        /* 입 모양 */
-        .mouth {
-            width: 180px;
-            height: 120px;
-            background: #1a1a2e;
-            border-radius: 50% 50% 50% 50% / 30% 30% 70% 70%;
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            border: 4px solid #ff6b9d;
-            overflow: hidden;
-            transition: all 0.3s ease;
+        /* SVG 입 스타일 */
+        .mouth-svg {
+            width: 100%;
+            height: 100%;
         }
 
-        .mouth.open {
-            height: 140px;
-            border-radius: 50% 50% 50% 50% / 20% 20% 80% 80%;
-        }
-
-        /* 혀 */
-        .tongue {
-            width: 80px;
-            height: 100px;
-            background: linear-gradient(180deg, #ff6b9d 0%, #e91e63 100%);
-            border-radius: 50% 50% 50% 50% / 40% 40% 60% 60%;
-            position: absolute;
-            bottom: -20px;
-            left: 50%;
-            transform: translateX(-50%);
+        /* 혀 애니메이션 */
+        #tongue {
             transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+            transform-origin: center bottom;
         }
 
-        /* 혀 올리기 애니메이션 */
-        .tongue.up {
-            bottom: 60px;
-            height: 60px;
-            border-radius: 50%;
-            box-shadow: 0 -10px 20px rgba(233, 30, 99, 0.5);
+        #tongue.up {
+            transform: translateY(-45px) scaleY(0.6);
         }
 
-        /* 혀 내밀기 애니메이션 */
-        .tongue.out {
-            bottom: -60px;
-            height: 140px;
-            border-radius: 45% 45% 50% 50% / 30% 30% 70% 70%;
+        #tongue.out {
+            transform: translateY(35px) scaleY(1.4);
         }
 
-        /* 혀 클릭 애니메이션 */
-        .tongue.click {
-            animation: tongueClick 0.3s ease;
+        #tongue.click {
+            animation: tongueClickSvg 0.4s ease;
         }
 
-        @keyframes tongueClick {
-            0% { bottom: -20px; }
-            50% { bottom: 40px; transform: translateX(-50%) scale(1.1); }
-            100% { bottom: -20px; }
+        @keyframes tongueClickSvg {
+            0% { transform: translateY(0) scaleY(1); }
+            30% { transform: translateY(-40px) scaleY(0.7); }
+            60% { transform: translateY(-40px) scaleY(0.7); }
+            100% { transform: translateY(0) scaleY(1); }
         }
 
-        /* 입천장 표시 */
-        .palate {
-            position: absolute;
-            top: 10px;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 100px;
-            height: 30px;
-            background: linear-gradient(180deg, #2d1f3d 0%, #1a1a2e 100%);
-            border-radius: 0 0 50% 50%;
+        /* 입 벌림 애니메이션 */
+        #lowerJaw {
+            transition: transform 0.3s ease;
+            transform-origin: center top;
+        }
+
+        .mouth-open #lowerJaw {
+            transform: translateY(20px);
+        }
+
+        /* 입천장 하이라이트 */
+        #palateHighlight {
             opacity: 0;
             transition: opacity 0.3s;
         }
 
-        .mouth.open .palate {
+        .tongue-up #palateHighlight {
             opacity: 1;
+            animation: palateGlow 1s infinite;
+        }
+
+        @keyframes palateGlow {
+            0%, 100% { opacity: 0.5; }
+            50% { opacity: 1; }
         }
 
         /* 운동 이름 */
@@ -169,6 +149,7 @@
             color: var(--text-muted);
             line-height: 1.6;
             min-height: 50px;
+            white-space: pre-line;
         }
 
         /* 타이머 영역 */
@@ -344,6 +325,30 @@
             margin-bottom: 20px;
         }
 
+        /* 시작 화면 미리보기 이미지 */
+        .preview-images {
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .preview-item {
+            text-align: center;
+        }
+
+        .preview-item svg {
+            width: 90px;
+            height: 80px;
+        }
+
+        .preview-label {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            margin-top: 5px;
+        }
+
         .exercise-list {
             text-align: left;
         }
@@ -457,18 +462,13 @@
             }
 
             .mouth-container {
-                width: 160px;
-                height: 160px;
+                width: 240px;
+                height: 200px;
             }
 
-            .mouth {
-                width: 140px;
-                height: 100px;
-            }
-
-            .tongue {
-                width: 60px;
-                height: 80px;
+            .preview-item svg {
+                width: 70px;
+                height: 60px;
             }
         }
     </style>
@@ -489,6 +489,59 @@
             </div>
 
             <div class="exercise-preview">
+                <!-- 미리보기 이미지 -->
+                <div class="preview-images">
+                    <div class="preview-item">
+                        <svg viewBox="0 0 100 90">
+                            <!-- 입 (기본) -->
+                            <ellipse cx="50" cy="45" rx="40" ry="35" fill="#2d1a1a"/>
+                            <!-- 위 입술 -->
+                            <path d="M15 40 Q50 25 85 40 Q50 50 15 40" fill="#e8a4a4"/>
+                            <!-- 아래 입술 -->
+                            <path d="M15 50 Q50 65 85 50 Q50 40 15 50" fill="#d49494"/>
+                            <!-- 윗니 -->
+                            <rect x="30" y="38" width="40" height="10" rx="2" fill="#fff"/>
+                            <!-- 혀 (올라간 상태) -->
+                            <ellipse cx="50" cy="42" rx="20" ry="12" fill="#e85a70"/>
+                            <!-- 입천장 표시 -->
+                            <path d="M30 35 Q50 28 70 35" stroke="#ffeb3b" stroke-width="3" fill="none" opacity="0.8"/>
+                        </svg>
+                        <div class="preview-label">혀 올리기</div>
+                    </div>
+                    <div class="preview-item">
+                        <svg viewBox="0 0 100 90">
+                            <!-- 입 (벌린 상태) -->
+                            <ellipse cx="50" cy="45" rx="40" ry="38" fill="#2d1a1a"/>
+                            <!-- 위 입술 -->
+                            <path d="M15 35 Q50 20 85 35 Q50 45 15 35" fill="#e8a4a4"/>
+                            <!-- 아래 입술 -->
+                            <path d="M15 60 Q50 80 85 60 Q50 50 15 60" fill="#d49494"/>
+                            <!-- 윗니 -->
+                            <rect x="30" y="33" width="40" height="10" rx="2" fill="#fff"/>
+                            <!-- 혀 (내민 상태) -->
+                            <path d="M35 55 Q50 95 65 55 Q60 50 50 48 Q40 50 35 55" fill="#e85a70"/>
+                        </svg>
+                        <div class="preview-label">혀 내밀기</div>
+                    </div>
+                    <div class="preview-item">
+                        <svg viewBox="0 0 100 90">
+                            <!-- 입 -->
+                            <ellipse cx="50" cy="45" rx="40" ry="35" fill="#2d1a1a"/>
+                            <!-- 위 입술 -->
+                            <path d="M15 40 Q50 25 85 40 Q50 50 15 40" fill="#e8a4a4"/>
+                            <!-- 아래 입술 -->
+                            <path d="M15 50 Q50 65 85 50 Q50 40 15 50" fill="#d49494"/>
+                            <!-- 윗니 -->
+                            <rect x="30" y="38" width="40" height="10" rx="2" fill="#fff"/>
+                            <!-- 혀 (클릭 효과) -->
+                            <ellipse cx="50" cy="48" rx="18" ry="10" fill="#e85a70"/>
+                            <!-- 클릭 효과 -->
+                            <text x="50" y="70" text-anchor="middle" font-size="12" fill="#fff">똑!</text>
+                        </svg>
+                        <div class="preview-label">혀 클릭</div>
+                    </div>
+                </div>
+
                 <div class="exercise-list">
                     <div class="exercise-item">
                         <div class="exercise-number">1</div>
@@ -530,11 +583,119 @@
             </div>
 
             <div class="animation-area">
-                <div class="mouth-container">
-                    <div class="mouth" id="mouth">
-                        <div class="palate"></div>
-                        <div class="tongue" id="tongue"></div>
-                    </div>
+                <div class="mouth-container" id="mouthContainer">
+                    <svg class="mouth-svg" viewBox="0 0 280 240">
+                        <defs>
+                            <!-- 입 내부 그라데이션 -->
+                            <radialGradient id="mouthInterior" cx="50%" cy="30%" r="70%">
+                                <stop offset="0%" stop-color="#3d2020"/>
+                                <stop offset="100%" stop-color="#1a0a0a"/>
+                            </radialGradient>
+                            <!-- 혀 그라데이션 -->
+                            <linearGradient id="tongueGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                                <stop offset="0%" stop-color="#ff7b8a"/>
+                                <stop offset="50%" stop-color="#e85a70"/>
+                                <stop offset="100%" stop-color="#c94058"/>
+                            </linearGradient>
+                            <!-- 입술 그라데이션 -->
+                            <linearGradient id="lipGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                                <stop offset="0%" stop-color="#f0b0b0"/>
+                                <stop offset="100%" stop-color="#d08080"/>
+                            </linearGradient>
+                            <!-- 아래 입술 그라데이션 -->
+                            <linearGradient id="lowerLipGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                                <stop offset="0%" stop-color="#d08080"/>
+                                <stop offset="100%" stop-color="#b06060"/>
+                            </linearGradient>
+                            <!-- 입천장 하이라이트 -->
+                            <linearGradient id="palateGlow" x1="0%" y1="0%" x2="0%" y2="100%">
+                                <stop offset="0%" stop-color="#ffeb3b"/>
+                                <stop offset="100%" stop-color="#ff9800"/>
+                            </linearGradient>
+                        </defs>
+
+                        <!-- 얼굴 배경 (피부) -->
+                        <ellipse cx="140" cy="120" rx="130" ry="110" fill="#f5d0c5"/>
+
+                        <!-- 입 내부 (어두운 부분) -->
+                        <ellipse cx="140" cy="130" rx="85" ry="70" fill="url(#mouthInterior)" id="mouthInterior"/>
+
+                        <!-- 윗니 -->
+                        <g id="upperTeeth">
+                            <rect x="60" y="68" width="160" height="28" rx="5" fill="#fafafa"/>
+                            <!-- 치아 구분선 -->
+                            <line x1="90" y1="68" x2="90" y2="96" stroke="#e0e0e0" stroke-width="1"/>
+                            <line x1="115" y1="68" x2="115" y2="96" stroke="#e0e0e0" stroke-width="1"/>
+                            <line x1="140" y1="68" x2="140" y2="96" stroke="#e0e0e0" stroke-width="1"/>
+                            <line x1="165" y1="68" x2="165" y2="96" stroke="#e0e0e0" stroke-width="1"/>
+                            <line x1="190" y1="68" x2="190" y2="96" stroke="#e0e0e0" stroke-width="1"/>
+                        </g>
+
+                        <!-- 입천장 -->
+                        <path d="M70 85 Q140 60 210 85 Q140 100 70 85" fill="#4a2828" id="palate"/>
+
+                        <!-- 입천장 하이라이트 (혀 올릴 때 표시) -->
+                        <path d="M85 82 Q140 65 195 82" stroke="url(#palateGlow)" stroke-width="6" fill="none"
+                              stroke-linecap="round" id="palateHighlight"/>
+
+                        <!-- 혀 -->
+                        <g id="tongue">
+                            <path d="M80 150
+                                     Q80 130 100 125
+                                     Q120 120 140 118
+                                     Q160 120 180 125
+                                     Q200 130 200 150
+                                     Q200 180 180 195
+                                     Q160 210 140 212
+                                     Q120 210 100 195
+                                     Q80 180 80 150"
+                                  fill="url(#tongueGradient)"/>
+                            <!-- 혀 중앙선 -->
+                            <path d="M140 125 Q140 160 140 195" stroke="#c94058" stroke-width="2" opacity="0.5"/>
+                            <!-- 혀 질감 -->
+                            <ellipse cx="120" cy="155" rx="15" ry="8" fill="#ff8a95" opacity="0.3"/>
+                            <ellipse cx="160" cy="155" rx="15" ry="8" fill="#ff8a95" opacity="0.3"/>
+                        </g>
+
+                        <!-- 아래쪽 (아랫니 + 아래 입술) -->
+                        <g id="lowerJaw">
+                            <!-- 아랫니 -->
+                            <rect x="65" y="185" width="150" height="22" rx="5" fill="#fafafa"/>
+                            <line x1="95" y1="185" x2="95" y2="207" stroke="#e0e0e0" stroke-width="1"/>
+                            <line x1="120" y1="185" x2="120" y2="207" stroke="#e0e0e0" stroke-width="1"/>
+                            <line x1="140" y1="185" x2="140" y2="207" stroke="#e0e0e0" stroke-width="1"/>
+                            <line x1="160" y1="185" x2="160" y2="207" stroke="#e0e0e0" stroke-width="1"/>
+                            <line x1="185" y1="185" x2="185" y2="207" stroke="#e0e0e0" stroke-width="1"/>
+
+                            <!-- 아래 입술 -->
+                            <path d="M30 200
+                                     Q80 195 140 195
+                                     Q200 195 250 200
+                                     Q230 235 140 240
+                                     Q50 235 30 200"
+                                  fill="url(#lowerLipGradient)"/>
+                            <!-- 아래 입술 하이라이트 -->
+                            <path d="M80 210 Q140 215 200 210" stroke="#e8a0a0" stroke-width="3" fill="none" opacity="0.5"/>
+                        </g>
+
+                        <!-- 위 입술 -->
+                        <g id="upperLip">
+                            <path d="M30 75
+                                     Q50 40 140 35
+                                     Q230 40 250 75
+                                     Q200 80 140 82
+                                     Q80 80 30 75"
+                                  fill="url(#lipGradient)"/>
+                            <!-- 인중 -->
+                            <path d="M140 35 L135 55 L140 60 L145 55 Z" fill="#e8b0b0"/>
+                            <!-- 입술 하이라이트 -->
+                            <ellipse cx="140" cy="55" rx="30" ry="8" fill="#ffcccc" opacity="0.4"/>
+                        </g>
+
+                        <!-- 입꼬리 그림자 -->
+                        <ellipse cx="45" cy="130" rx="12" ry="20" fill="#e0b0a0" opacity="0.5"/>
+                        <ellipse cx="235" cy="130" rx="12" ry="20" fill="#e0b0a0" opacity="0.5"/>
+                    </svg>
                 </div>
 
                 <div class="exercise-name" id="exerciseStatus">준비</div>
@@ -640,8 +801,10 @@
             progressBar: document.getElementById('progressBar'),
             progressText: document.getElementById('progressText'),
             repCounter: document.getElementById('repCounter'),
-            mouth: document.getElementById('mouth'),
+            mouthContainer: document.getElementById('mouthContainer'),
             tongue: document.getElementById('tongue'),
+            lowerJaw: document.getElementById('lowerJaw'),
+            palateHighlight: document.getElementById('palateHighlight'),
             streakCount: document.getElementById('streakCount'),
             totalTime: document.getElementById('totalTime')
         };
@@ -650,7 +813,6 @@
         function speak(text) {
             if (!state.voiceEnabled) return;
 
-            // 기존 음성 중지
             window.speechSynthesis.cancel();
 
             const utterance = new SpeechSynthesisUtterance(text);
@@ -658,7 +820,6 @@
             utterance.rate = 1.0;
             utterance.pitch = 1.0;
 
-            // 한국어 음성 찾기
             const voices = window.speechSynthesis.getVoices();
             const koreanVoice = voices.find(v => v.lang.includes('ko'));
             if (koreanVoice) {
@@ -668,7 +829,6 @@
             window.speechSynthesis.speak(utterance);
         }
 
-        // 음성 목록 로드 대기
         window.speechSynthesis.onvoiceschanged = () => {
             window.speechSynthesis.getVoices();
         };
@@ -680,13 +840,10 @@
             const yesterday = new Date(Date.now() - 86400000).toDateString();
 
             if (data.lastDate === today) {
-                // 오늘 이미 했음
                 return data.streak || 1;
             } else if (data.lastDate === yesterday) {
-                // 어제 했음 - 연속 유지
                 return data.streak || 1;
             } else {
-                // 연속 끊김
                 return 0;
             }
         }
@@ -739,18 +896,26 @@
         }
 
         function setTongueAnimation(type) {
-            elements.tongue.classList.remove('up', 'out', 'click');
-            elements.mouth.classList.remove('open');
+            const tongue = elements.tongue;
+            const container = elements.mouthContainer;
+
+            // 모든 클래스 제거
+            tongue.classList.remove('up', 'out', 'click');
+            container.classList.remove('mouth-open', 'tongue-up');
 
             if (type === 'up') {
-                elements.mouth.classList.add('open');
-                elements.tongue.classList.add('up');
+                container.classList.add('mouth-open', 'tongue-up');
+                tongue.classList.add('up');
             } else if (type === 'out') {
-                elements.mouth.classList.add('open');
-                elements.tongue.classList.add('out');
+                container.classList.add('mouth-open');
+                tongue.classList.add('out');
             } else if (type === 'click') {
-                elements.mouth.classList.add('open');
-                elements.tongue.classList.add('click');
+                container.classList.add('mouth-open');
+                tongue.classList.add('click');
+                // 클릭 애니메이션 후 원위치
+                setTimeout(() => {
+                    tongue.classList.remove('click');
+                }, 400);
             }
         }
 
@@ -768,7 +933,6 @@
                 state.timerValue--;
                 elements.timerDisplay.textContent = state.timerValue;
 
-                // 카운트다운 음성
                 if (state.timerValue <= 3 && state.timerValue > 0) {
                     speak(state.timerValue.toString());
                 }
@@ -826,7 +990,6 @@
             const exercise = ROUTINE[state.currentExercise];
 
             if (state.currentRep >= exercise.reps) {
-                // 이 운동 완료
                 nextExercise();
                 return;
             }
@@ -835,7 +998,6 @@
             updateProgress();
 
             if (exercise.hold > 0) {
-                // 유지 운동 (혀 올리기, 내밀기)
                 elements.exerciseStatus.textContent = '유지';
                 setTongueAnimation(exercise.animation);
                 speak(exercise.instruction.split('\n')[0]);
@@ -853,7 +1015,6 @@
                     }
                 });
             } else {
-                // 클릭 운동
                 elements.exerciseStatus.textContent = '클릭!';
                 elements.timerDisplay.textContent = `${state.currentRep + 1}`;
                 elements.timerDisplay.classList.remove('counting', 'rest');
@@ -861,7 +1022,6 @@
                 speak('클릭');
                 setTongueAnimation('click');
 
-                // 성공 버튼 표시
                 elements.successBtn.classList.remove('hidden');
             }
         }
@@ -870,7 +1030,6 @@
             const exercise = ROUTINE[state.currentExercise];
 
             if (exercise.hold === 0) {
-                // 클릭 운동 - 성공 버튼으로 진행
                 setTongueAnimation('click');
                 state.currentRep++;
 
@@ -914,7 +1073,7 @@
             function tick() {
                 elements.countdownNumber.textContent = count;
                 elements.countdownNumber.style.animation = 'none';
-                elements.countdownNumber.offsetHeight; // 리플로우
+                elements.countdownNumber.offsetHeight;
                 elements.countdownNumber.style.animation = 'countdownPop 1s ease';
 
                 speak(count.toString());
@@ -999,8 +1158,6 @@
         function init() {
             const streak = loadStreak();
             elements.streakCount.textContent = streak;
-
-            // 음성 엔진 준비
             window.speechSynthesis.getVoices();
         }
 

--- a/tongue-training.html
+++ b/tongue-training.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>혀 훈련 - 8분 루틴</title>
+    <title>혀 훈련</title>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
         * {
             margin: 0;
             padding: 0;
@@ -12,305 +14,103 @@
         }
 
         :root {
-            --primary: #6366f1;
-            --primary-dark: #4f46e5;
-            --success: #22c55e;
-            --bg: #0f172a;
-            --card: #1e293b;
-            --text: #f8fafc;
-            --text-muted: #94a3b8;
+            --bg-dark: #0a0a0f;
+            --glass: rgba(255, 255, 255, 0.03);
+            --glass-border: rgba(255, 255, 255, 0.08);
+            --text-primary: rgba(255, 255, 255, 0.95);
+            --text-secondary: rgba(255, 255, 255, 0.5);
+            --text-tertiary: rgba(255, 255, 255, 0.3);
+            --accent-1: #6366f1;
+            --accent-2: #8b5cf6;
+            --accent-3: #ec4899;
+            --success: #10b981;
         }
 
         body {
-            font-family: -apple-system, 'SF Pro Display', 'Pretendard', 'Apple SD Gothic Neo', sans-serif;
-            background: var(--bg);
-            color: var(--text);
+            font-family: 'Inter', -apple-system, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            min-height: 100vh;
+            overflow: hidden;
+            position: relative;
+        }
+
+        /* 배경 그라데이션 오브 */
+        .bg-orbs {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            pointer-events: none;
+            overflow: hidden;
+        }
+
+        .orb {
+            position: absolute;
+            border-radius: 50%;
+            filter: blur(80px);
+            opacity: 0.4;
+            animation: float 20s ease-in-out infinite;
+        }
+
+        .orb-1 {
+            width: 400px;
+            height: 400px;
+            background: linear-gradient(135deg, #6366f1, #8b5cf6);
+            top: -150px;
+            right: -100px;
+            animation-delay: 0s;
+        }
+
+        .orb-2 {
+            width: 300px;
+            height: 300px;
+            background: linear-gradient(135deg, #ec4899, #8b5cf6);
+            bottom: -100px;
+            left: -100px;
+            animation-delay: -7s;
+        }
+
+        .orb-3 {
+            width: 200px;
+            height: 200px;
+            background: linear-gradient(135deg, #06b6d4, #6366f1);
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            animation-delay: -14s;
+        }
+
+        @keyframes float {
+            0%, 100% { transform: translate(0, 0) scale(1); }
+            25% { transform: translate(30px, -30px) scale(1.05); }
+            50% { transform: translate(-20px, 20px) scale(0.95); }
+            75% { transform: translate(20px, 30px) scale(1.02); }
+        }
+
+        /* 메인 컨테이너 */
+        .container {
+            position: relative;
+            z-index: 1;
             min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            padding: 20px;
-            overflow: hidden;
+            padding: 24px;
         }
 
-        .container {
+        /* 글래스 카드 */
+        .glass-card {
+            background: var(--glass);
+            backdrop-filter: blur(40px);
+            -webkit-backdrop-filter: blur(40px);
+            border: 1px solid var(--glass-border);
+            border-radius: 32px;
+            padding: 40px 32px;
             width: 100%;
-            max-width: 420px;
-            text-align: center;
-        }
-
-        /* 헤더 */
-        .header {
-            margin-bottom: 20px;
-        }
-
-        .title {
-            font-size: 1.5rem;
-            font-weight: 700;
-            margin-bottom: 8px;
-        }
-
-        .streak-badge {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            background: linear-gradient(135deg, #f97316, #ef4444);
-            padding: 6px 14px;
-            border-radius: 20px;
-            font-size: 0.9rem;
-            font-weight: 600;
-        }
-
-        /* 메인 애니메이션 영역 */
-        .animation-area {
-            background: var(--card);
-            border-radius: 24px;
-            padding: 30px 20px;
-            margin-bottom: 20px;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .mouth-container {
-            width: 280px;
-            height: 240px;
-            margin: 0 auto 20px;
-            position: relative;
-        }
-
-        /* SVG 입 스타일 */
-        .mouth-svg {
-            width: 100%;
-            height: 100%;
-        }
-
-        /* 혀 애니메이션 */
-        #tongue {
-            transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
-            transform-origin: center bottom;
-        }
-
-        #tongue.up {
-            transform: translateY(-45px) scaleY(0.6);
-        }
-
-        #tongue.out {
-            transform: translateY(35px) scaleY(1.4);
-        }
-
-        #tongue.click {
-            animation: tongueClickSvg 0.4s ease;
-        }
-
-        @keyframes tongueClickSvg {
-            0% { transform: translateY(0) scaleY(1); }
-            30% { transform: translateY(-40px) scaleY(0.7); }
-            60% { transform: translateY(-40px) scaleY(0.7); }
-            100% { transform: translateY(0) scaleY(1); }
-        }
-
-        /* 입 벌림 애니메이션 */
-        #lowerJaw {
-            transition: transform 0.3s ease;
-            transform-origin: center top;
-        }
-
-        .mouth-open #lowerJaw {
-            transform: translateY(20px);
-        }
-
-        /* 입천장 하이라이트 */
-        #palateHighlight {
-            opacity: 0;
-            transition: opacity 0.3s;
-        }
-
-        .tongue-up #palateHighlight {
-            opacity: 1;
-            animation: palateGlow 1s infinite;
-        }
-
-        @keyframes palateGlow {
-            0%, 100% { opacity: 0.5; }
-            50% { opacity: 1; }
-        }
-
-        /* 운동 이름 */
-        .exercise-name {
-            font-size: 1.8rem;
-            font-weight: 700;
-            margin-bottom: 10px;
-            color: var(--primary);
-        }
-
-        .exercise-instruction {
-            font-size: 1.1rem;
-            color: var(--text-muted);
-            line-height: 1.6;
-            min-height: 50px;
-            white-space: pre-line;
-        }
-
-        /* 타이머 영역 */
-        .timer-section {
-            margin-bottom: 24px;
-        }
-
-        .timer-display {
-            font-size: 4rem;
-            font-weight: 700;
-            font-variant-numeric: tabular-nums;
-            margin-bottom: 12px;
-        }
-
-        .timer-display.counting {
-            color: var(--primary);
-        }
-
-        .timer-display.rest {
-            color: var(--success);
-        }
-
-        /* 프로그레스 바 */
-        .progress-container {
-            background: var(--card);
-            border-radius: 10px;
-            height: 12px;
-            overflow: hidden;
-            margin-bottom: 8px;
-        }
-
-        .progress-bar {
-            height: 100%;
-            background: linear-gradient(90deg, var(--primary), #8b5cf6);
-            border-radius: 10px;
-            transition: width 0.3s ease;
-        }
-
-        .progress-text {
-            font-size: 0.9rem;
-            color: var(--text-muted);
-        }
-
-        /* 반복 카운터 */
-        .rep-counter {
-            display: flex;
-            justify-content: center;
-            gap: 8px;
-            margin-bottom: 20px;
-            flex-wrap: wrap;
-        }
-
-        .rep-dot {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            background: var(--card);
-            border: 2px solid var(--text-muted);
-            transition: all 0.3s;
-        }
-
-        .rep-dot.completed {
-            background: var(--success);
-            border-color: var(--success);
-            transform: scale(1.1);
-        }
-
-        .rep-dot.current {
-            border-color: var(--primary);
-            box-shadow: 0 0 10px var(--primary);
-            animation: pulse 1s infinite;
-        }
-
-        @keyframes pulse {
-            0%, 100% { transform: scale(1); }
-            50% { transform: scale(1.2); }
-        }
-
-        /* 버튼 */
-        .btn {
-            width: 100%;
-            padding: 18px 32px;
-            font-size: 1.2rem;
-            font-weight: 700;
-            border: none;
-            border-radius: 16px;
-            cursor: pointer;
-            transition: all 0.3s;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 10px;
-        }
-
-        .btn-primary {
-            background: linear-gradient(135deg, var(--primary), #8b5cf6);
-            color: white;
-            box-shadow: 0 4px 20px rgba(99, 102, 241, 0.4);
-        }
-
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 30px rgba(99, 102, 241, 0.5);
-        }
-
-        .btn-primary:active {
-            transform: translateY(0);
-        }
-
-        .btn-success {
-            background: linear-gradient(135deg, var(--success), #16a34a);
-            color: white;
-        }
-
-        .btn-secondary {
-            background: var(--card);
-            color: var(--text);
-            border: 2px solid var(--text-muted);
-        }
-
-        .btn:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
-            transform: none;
-        }
-
-        /* 완료 화면 */
-        .complete-screen {
-            display: none;
-            text-align: center;
-            padding: 40px 20px;
-        }
-
-        .complete-screen.show {
-            display: block;
-            animation: fadeIn 0.5s ease;
-        }
-
-        @keyframes fadeIn {
-            from { opacity: 0; transform: scale(0.9); }
-            to { opacity: 1; transform: scale(1); }
-        }
-
-        .complete-icon {
-            font-size: 5rem;
-            margin-bottom: 20px;
-        }
-
-        .complete-title {
-            font-size: 2rem;
-            font-weight: 700;
-            margin-bottom: 10px;
-            background: linear-gradient(135deg, var(--success), #22d3ee);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-
-        .complete-stats {
-            color: var(--text-muted);
-            margin-bottom: 30px;
+            max-width: 400px;
         }
 
         /* 시작 화면 */
@@ -318,120 +118,403 @@
             text-align: center;
         }
 
-        .start-screen .exercise-preview {
-            background: var(--card);
-            border-radius: 16px;
-            padding: 20px;
-            margin-bottom: 20px;
+        .logo {
+            font-size: 0.75rem;
+            font-weight: 500;
+            letter-spacing: 3px;
+            text-transform: uppercase;
+            color: var(--text-tertiary);
+            margin-bottom: 32px;
         }
 
-        /* 시작 화면 미리보기 이미지 */
-        .preview-images {
+        .main-title {
+            font-size: 2rem;
+            font-weight: 300;
+            letter-spacing: -0.5px;
+            margin-bottom: 8px;
+        }
+
+        .subtitle {
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+            margin-bottom: 40px;
+        }
+
+        /* 운동 미리보기 */
+        .exercise-preview {
             display: flex;
-            justify-content: center;
-            gap: 15px;
-            margin-bottom: 20px;
-            flex-wrap: wrap;
+            flex-direction: column;
+            gap: 12px;
+            margin-bottom: 40px;
         }
 
         .preview-item {
-            text-align: center;
-        }
-
-        .preview-item svg {
-            width: 90px;
-            height: 80px;
-        }
-
-        .preview-label {
-            font-size: 0.75rem;
-            color: var(--text-muted);
-            margin-top: 5px;
-        }
-
-        .exercise-list {
-            text-align: left;
-        }
-
-        .exercise-item {
             display: flex;
             align-items: center;
-            gap: 12px;
-            padding: 12px 0;
-            border-bottom: 1px solid rgba(255,255,255,0.1);
+            gap: 16px;
+            padding: 16px;
+            background: rgba(255, 255, 255, 0.02);
+            border-radius: 16px;
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            transition: all 0.3s ease;
         }
 
-        .exercise-item:last-child {
-            border-bottom: none;
-        }
-
-        .exercise-number {
-            width: 32px;
-            height: 32px;
-            background: var(--primary);
-            border-radius: 50%;
+        .preview-icon {
+            width: 48px;
+            height: 48px;
+            border-radius: 14px;
             display: flex;
             align-items: center;
             justify-content: center;
-            font-weight: 700;
-            font-size: 0.9rem;
+            font-size: 1.2rem;
+            background: linear-gradient(135deg, var(--accent-1), var(--accent-2));
+            flex-shrink: 0;
         }
 
-        .exercise-info {
+        .preview-info {
             flex: 1;
+            text-align: left;
         }
 
-        .exercise-info-name {
-            font-weight: 600;
+        .preview-name {
+            font-size: 0.95rem;
+            font-weight: 500;
             margin-bottom: 2px;
         }
 
-        .exercise-info-detail {
-            font-size: 0.85rem;
-            color: var(--text-muted);
+        .preview-detail {
+            font-size: 0.8rem;
+            color: var(--text-tertiary);
         }
 
-        /* 훈련 화면 */
+        /* 스타트 버튼 */
+        .btn-start {
+            width: 100%;
+            padding: 18px;
+            font-size: 1rem;
+            font-weight: 500;
+            font-family: inherit;
+            border: none;
+            border-radius: 16px;
+            cursor: pointer;
+            background: linear-gradient(135deg, var(--accent-1), var(--accent-2));
+            color: white;
+            transition: all 0.3s ease;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .btn-start::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: linear-gradient(135deg, var(--accent-2), var(--accent-3));
+            opacity: 0;
+            transition: opacity 0.3s;
+        }
+
+        .btn-start:hover::before {
+            opacity: 1;
+        }
+
+        .btn-start span {
+            position: relative;
+            z-index: 1;
+        }
+
+        /* 연속일 뱃지 */
+        .streak-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 8px 16px;
+            background: rgba(251, 146, 60, 0.15);
+            border: 1px solid rgba(251, 146, 60, 0.3);
+            border-radius: 100px;
+            font-size: 0.85rem;
+            color: #fb923c;
+            margin-bottom: 32px;
+        }
+
+        /* ========== 훈련 화면 ========== */
         .training-screen {
             display: none;
+            text-align: center;
         }
 
         .training-screen.show {
             display: block;
         }
 
-        /* 숨김 */
-        .hidden {
-            display: none !important;
+        .exercise-title {
+            font-size: 0.75rem;
+            font-weight: 500;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            color: var(--text-tertiary);
+            margin-bottom: 8px;
         }
 
-        /* 음성 토글 */
-        .voice-toggle {
-            position: fixed;
-            top: 20px;
-            right: 20px;
-            background: var(--card);
-            border: none;
-            border-radius: 50%;
-            width: 48px;
-            height: 48px;
+        .exercise-name {
             font-size: 1.5rem;
+            font-weight: 400;
+            margin-bottom: 32px;
+        }
+
+        /* 입 애니메이션 컨테이너 */
+        .mouth-visual {
+            width: 220px;
+            height: 220px;
+            margin: 0 auto 32px;
+            position: relative;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        /* 원형 프로그레스 링 */
+        .progress-ring {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+
+        .progress-ring circle {
+            fill: none;
+            stroke-width: 3;
+            transform: rotate(-90deg);
+            transform-origin: 50% 50%;
+        }
+
+        .progress-ring .bg {
+            stroke: rgba(255, 255, 255, 0.08);
+        }
+
+        .progress-ring .progress {
+            stroke: url(#progressGradient);
+            stroke-linecap: round;
+            transition: stroke-dashoffset 0.3s ease;
+        }
+
+        /* 입 SVG */
+        .mouth-svg {
+            width: 160px;
+            height: 160px;
+        }
+
+        #tongue {
+            transition: all 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+            transform-origin: center bottom;
+        }
+
+        #tongue.up {
+            transform: translateY(-35px) scaleY(0.5);
+        }
+
+        #tongue.out {
+            transform: translateY(25px) scaleY(1.3);
+        }
+
+        #tongue.click {
+            animation: tongueClick 0.4s ease;
+        }
+
+        @keyframes tongueClick {
+            0% { transform: translateY(0) scaleY(1); }
+            30% { transform: translateY(-30px) scaleY(0.6); }
+            60% { transform: translateY(-30px) scaleY(0.6); }
+            100% { transform: translateY(0) scaleY(1); }
+        }
+
+        #lowerJaw {
+            transition: transform 0.4s ease;
+            transform-origin: center top;
+        }
+
+        .mouth-open #lowerJaw {
+            transform: translateY(15px);
+        }
+
+        #palateGlow {
+            opacity: 0;
+            transition: opacity 0.3s;
+        }
+
+        .tongue-up #palateGlow {
+            opacity: 1;
+            animation: glow 1.5s ease-in-out infinite;
+        }
+
+        @keyframes glow {
+            0%, 100% { opacity: 0.4; }
+            50% { opacity: 1; }
+        }
+
+        /* 타이머 */
+        .timer-display {
+            font-size: 4.5rem;
+            font-weight: 200;
+            letter-spacing: -4px;
+            margin-bottom: 8px;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .timer-label {
+            font-size: 0.85rem;
+            color: var(--text-tertiary);
+            margin-bottom: 32px;
+        }
+
+        /* 반복 인디케이터 */
+        .rep-indicator {
+            display: flex;
+            justify-content: center;
+            gap: 6px;
+            margin-bottom: 32px;
+            flex-wrap: wrap;
+            max-width: 280px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .rep-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.1);
+            transition: all 0.3s ease;
+        }
+
+        .rep-dot.completed {
+            background: var(--success);
+            box-shadow: 0 0 10px rgba(16, 185, 129, 0.5);
+        }
+
+        .rep-dot.current {
+            background: var(--accent-1);
+            box-shadow: 0 0 10px rgba(99, 102, 241, 0.5);
+            animation: pulse 1.5s ease-in-out infinite;
+        }
+
+        @keyframes pulse {
+            0%, 100% { transform: scale(1); opacity: 1; }
+            50% { transform: scale(1.3); opacity: 0.7; }
+        }
+
+        /* 완료 버튼 */
+        .btn-done {
+            width: 100%;
+            padding: 16px;
+            font-size: 0.95rem;
+            font-weight: 500;
+            font-family: inherit;
+            border: 1px solid rgba(16, 185, 129, 0.3);
+            border-radius: 14px;
             cursor: pointer;
-            transition: all 0.3s;
+            background: rgba(16, 185, 129, 0.1);
+            color: var(--success);
+            transition: all 0.3s ease;
         }
 
-        .voice-toggle:hover {
-            background: var(--primary);
+        .btn-done:hover {
+            background: rgba(16, 185, 129, 0.2);
         }
 
-        /* 카운트다운 오버레이 */
+        /* ========== 완료 화면 ========== */
+        .complete-screen {
+            display: none;
+            text-align: center;
+        }
+
+        .complete-screen.show {
+            display: block;
+            animation: fadeIn 0.6s ease;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(20px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        .complete-visual {
+            width: 120px;
+            height: 120px;
+            margin: 0 auto 32px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, var(--success), #06b6d4);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 3rem;
+        }
+
+        .complete-title {
+            font-size: 1.75rem;
+            font-weight: 400;
+            margin-bottom: 8px;
+        }
+
+        .complete-subtitle {
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+            margin-bottom: 32px;
+        }
+
+        .stat-row {
+            display: flex;
+            justify-content: center;
+            gap: 32px;
+            margin-bottom: 32px;
+        }
+
+        .stat-item {
+            text-align: center;
+        }
+
+        .stat-value {
+            font-size: 1.5rem;
+            font-weight: 500;
+            margin-bottom: 4px;
+        }
+
+        .stat-label {
+            font-size: 0.75rem;
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .btn-restart {
+            width: 100%;
+            padding: 16px;
+            font-size: 0.95rem;
+            font-weight: 500;
+            font-family: inherit;
+            border: 1px solid var(--glass-border);
+            border-radius: 14px;
+            cursor: pointer;
+            background: var(--glass);
+            color: var(--text-primary);
+            transition: all 0.3s ease;
+        }
+
+        .btn-restart:hover {
+            background: rgba(255, 255, 255, 0.08);
+        }
+
+        /* ========== 카운트다운 오버레이 ========== */
         .countdown-overlay {
             position: fixed;
             top: 0;
             left: 0;
             right: 0;
             bottom: 0;
-            background: rgba(15, 23, 42, 0.95);
+            background: rgba(10, 10, 15, 0.95);
             display: none;
             align-items: center;
             justify-content: center;
@@ -443,463 +526,357 @@
         }
 
         .countdown-number {
-            font-size: 8rem;
-            font-weight: 700;
-            color: var(--primary);
-            animation: countdownPop 1s ease;
+            font-size: 10rem;
+            font-weight: 200;
+            background: linear-gradient(135deg, var(--accent-1), var(--accent-3));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            animation: countPop 1s ease;
         }
 
-        @keyframes countdownPop {
+        @keyframes countPop {
             0% { transform: scale(0.5); opacity: 0; }
-            50% { transform: scale(1.2); }
+            50% { transform: scale(1.1); }
             100% { transform: scale(1); opacity: 1; }
         }
 
+        /* ========== 컨트롤 버튼 ========== */
+        .controls {
+            position: fixed;
+            top: 24px;
+            right: 24px;
+            display: flex;
+            gap: 12px;
+            z-index: 10;
+        }
+
+        .control-btn {
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            border: 1px solid var(--glass-border);
+            background: var(--glass);
+            backdrop-filter: blur(20px);
+            color: var(--text-secondary);
+            font-size: 1.1rem;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .control-btn:hover {
+            background: rgba(255, 255, 255, 0.1);
+            color: var(--text-primary);
+        }
+
+        /* 숨김 */
+        .hidden {
+            display: none !important;
+        }
+
         /* 반응형 */
-        @media (max-width: 380px) {
+        @media (max-width: 420px) {
+            .glass-card {
+                padding: 32px 24px;
+                border-radius: 24px;
+            }
+
             .timer-display {
-                font-size: 3rem;
+                font-size: 3.5rem;
             }
 
-            .mouth-container {
-                width: 240px;
-                height: 200px;
+            .mouth-visual {
+                width: 180px;
+                height: 180px;
             }
 
-            .preview-item svg {
-                width: 70px;
-                height: 60px;
+            .mouth-svg {
+                width: 130px;
+                height: 130px;
             }
         }
     </style>
 </head>
 <body>
-    <button class="voice-toggle" id="voiceToggle" title="음성 켜기/끄기">
-        🔊
-    </button>
+    <!-- 배경 오브 -->
+    <div class="bg-orbs">
+        <div class="orb orb-1"></div>
+        <div class="orb orb-2"></div>
+        <div class="orb orb-3"></div>
+    </div>
+
+    <!-- 컨트롤 -->
+    <div class="controls">
+        <button class="control-btn" id="voiceToggle" title="음성">🔊</button>
+    </div>
 
     <div class="container">
-        <!-- 시작 화면 -->
-        <div class="start-screen" id="startScreen">
-            <div class="header">
-                <h1 class="title">오늘의 혀 훈련</h1>
-                <div class="streak-badge" id="streakBadge">
-                    🔥 <span id="streakCount">0</span>일 연속
-                </div>
+        <!-- ========== 시작 화면 ========== -->
+        <div class="glass-card start-screen" id="startScreen">
+            <div class="logo">Tongue Training</div>
+
+            <div class="streak-badge" id="streakBadge">
+                🔥 <span id="streakCount">0</span>일 연속
             </div>
+
+            <h1 class="main-title">오늘의 훈련</h1>
+            <p class="subtitle">8분 · 3가지 운동</p>
 
             <div class="exercise-preview">
-                <!-- 미리보기 이미지 -->
-                <div class="preview-images">
-                    <div class="preview-item">
-                        <svg viewBox="0 0 100 90">
-                            <!-- 입 (기본) -->
-                            <ellipse cx="50" cy="45" rx="40" ry="35" fill="#2d1a1a"/>
-                            <!-- 위 입술 -->
-                            <path d="M15 40 Q50 25 85 40 Q50 50 15 40" fill="#e8a4a4"/>
-                            <!-- 아래 입술 -->
-                            <path d="M15 50 Q50 65 85 50 Q50 40 15 50" fill="#d49494"/>
-                            <!-- 윗니 -->
-                            <rect x="30" y="38" width="40" height="10" rx="2" fill="#fff"/>
-                            <!-- 혀 (올라간 상태) -->
-                            <ellipse cx="50" cy="42" rx="20" ry="12" fill="#e85a70"/>
-                            <!-- 입천장 표시 -->
-                            <path d="M30 35 Q50 28 70 35" stroke="#ffeb3b" stroke-width="3" fill="none" opacity="0.8"/>
-                        </svg>
-                        <div class="preview-label">혀 올리기</div>
-                    </div>
-                    <div class="preview-item">
-                        <svg viewBox="0 0 100 90">
-                            <!-- 입 (벌린 상태) -->
-                            <ellipse cx="50" cy="45" rx="40" ry="38" fill="#2d1a1a"/>
-                            <!-- 위 입술 -->
-                            <path d="M15 35 Q50 20 85 35 Q50 45 15 35" fill="#e8a4a4"/>
-                            <!-- 아래 입술 -->
-                            <path d="M15 60 Q50 80 85 60 Q50 50 15 60" fill="#d49494"/>
-                            <!-- 윗니 -->
-                            <rect x="30" y="33" width="40" height="10" rx="2" fill="#fff"/>
-                            <!-- 혀 (내민 상태) -->
-                            <path d="M35 55 Q50 95 65 55 Q60 50 50 48 Q40 50 35 55" fill="#e85a70"/>
-                        </svg>
-                        <div class="preview-label">혀 내밀기</div>
-                    </div>
-                    <div class="preview-item">
-                        <svg viewBox="0 0 100 90">
-                            <!-- 입 -->
-                            <ellipse cx="50" cy="45" rx="40" ry="35" fill="#2d1a1a"/>
-                            <!-- 위 입술 -->
-                            <path d="M15 40 Q50 25 85 40 Q50 50 15 40" fill="#e8a4a4"/>
-                            <!-- 아래 입술 -->
-                            <path d="M15 50 Q50 65 85 50 Q50 40 15 50" fill="#d49494"/>
-                            <!-- 윗니 -->
-                            <rect x="30" y="38" width="40" height="10" rx="2" fill="#fff"/>
-                            <!-- 혀 (클릭 효과) -->
-                            <ellipse cx="50" cy="48" rx="18" ry="10" fill="#e85a70"/>
-                            <!-- 클릭 효과 -->
-                            <text x="50" y="70" text-anchor="middle" font-size="12" fill="#fff">똑!</text>
-                        </svg>
-                        <div class="preview-label">혀 클릭</div>
+                <div class="preview-item">
+                    <div class="preview-icon">↑</div>
+                    <div class="preview-info">
+                        <div class="preview-name">혀 올리기</div>
+                        <div class="preview-detail">5초 × 10회</div>
                     </div>
                 </div>
-
-                <div class="exercise-list">
-                    <div class="exercise-item">
-                        <div class="exercise-number">1</div>
-                        <div class="exercise-info">
-                            <div class="exercise-info-name">혀 올리기</div>
-                            <div class="exercise-info-detail">5초 유지 × 10회</div>
-                        </div>
+                <div class="preview-item">
+                    <div class="preview-icon">→</div>
+                    <div class="preview-info">
+                        <div class="preview-name">혀 내밀기</div>
+                        <div class="preview-detail">3초 × 10회</div>
                     </div>
-                    <div class="exercise-item">
-                        <div class="exercise-number">2</div>
-                        <div class="exercise-info">
-                            <div class="exercise-info-name">혀 내밀기</div>
-                            <div class="exercise-info-detail">3초 유지 × 10회</div>
-                        </div>
-                    </div>
-                    <div class="exercise-item">
-                        <div class="exercise-number">3</div>
-                        <div class="exercise-info">
-                            <div class="exercise-info-name">혀 클릭</div>
-                            <div class="exercise-info-detail">15회</div>
-                        </div>
+                </div>
+                <div class="preview-item">
+                    <div class="preview-icon">◉</div>
+                    <div class="preview-info">
+                        <div class="preview-name">혀 클릭</div>
+                        <div class="preview-detail">15회</div>
                     </div>
                 </div>
             </div>
 
-            <p style="color: var(--text-muted); margin-bottom: 20px; font-size: 0.95rem;">
-                약 8분 소요 • 눈 감고도 가능
-            </p>
-
-            <button class="btn btn-primary" id="startBtn">
-                ▶ 시작하기
+            <button class="btn-start" id="startBtn">
+                <span>시작하기</span>
             </button>
         </div>
 
-        <!-- 훈련 화면 -->
-        <div class="training-screen" id="trainingScreen">
-            <div class="header">
-                <h1 class="title" id="currentExerciseTitle">혀 올리기</h1>
+        <!-- ========== 훈련 화면 ========== -->
+        <div class="glass-card training-screen" id="trainingScreen">
+            <div class="exercise-title">운동 <span id="exerciseNum">1</span>/3</div>
+            <h2 class="exercise-name" id="exerciseName">혀 올리기</h2>
+
+            <div class="mouth-visual" id="mouthContainer">
+                <!-- 프로그레스 링 -->
+                <svg class="progress-ring" viewBox="0 0 220 220">
+                    <defs>
+                        <linearGradient id="progressGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                            <stop offset="0%" stop-color="#6366f1"/>
+                            <stop offset="100%" stop-color="#ec4899"/>
+                        </linearGradient>
+                    </defs>
+                    <circle class="bg" cx="110" cy="110" r="106"/>
+                    <circle class="progress" id="progressCircle" cx="110" cy="110" r="106"
+                            stroke-dasharray="666" stroke-dashoffset="666"/>
+                </svg>
+
+                <!-- 입 SVG -->
+                <svg class="mouth-svg" viewBox="0 0 160 160">
+                    <defs>
+                        <radialGradient id="mouthBg" cx="50%" cy="40%" r="60%">
+                            <stop offset="0%" stop-color="#2d1a2d"/>
+                            <stop offset="100%" stop-color="#150a15"/>
+                        </radialGradient>
+                        <linearGradient id="tongueGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+                            <stop offset="0%" stop-color="#ff7b8a"/>
+                            <stop offset="50%" stop-color="#e85a70"/>
+                            <stop offset="100%" stop-color="#c94058"/>
+                        </linearGradient>
+                        <linearGradient id="lipGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+                            <stop offset="0%" stop-color="#e8a0a0"/>
+                            <stop offset="100%" stop-color="#c08080"/>
+                        </linearGradient>
+                        <linearGradient id="glowGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+                            <stop offset="0%" stop-color="#6366f1"/>
+                            <stop offset="100%" stop-color="#ec4899"/>
+                        </linearGradient>
+                    </defs>
+
+                    <!-- 피부 배경 -->
+                    <ellipse cx="80" cy="80" rx="75" ry="70" fill="#f0c8c0"/>
+
+                    <!-- 입 내부 -->
+                    <ellipse cx="80" cy="85" rx="50" ry="45" fill="url(#mouthBg)"/>
+
+                    <!-- 윗니 -->
+                    <rect x="35" y="45" width="90" height="18" rx="4" fill="#fafafa"/>
+
+                    <!-- 입천장 -->
+                    <path d="M40 55 Q80 40 120 55" fill="#3d2030"/>
+
+                    <!-- 입천장 글로우 -->
+                    <path d="M45 52 Q80 40 115 52" stroke="url(#glowGrad)" stroke-width="4"
+                          fill="none" stroke-linecap="round" id="palateGlow"/>
+
+                    <!-- 혀 -->
+                    <g id="tongue">
+                        <path d="M45 95 Q45 80 60 75 Q80 72 100 75 Q115 80 115 95 Q115 115 100 125 Q80 132 60 125 Q45 115 45 95"
+                              fill="url(#tongueGrad)"/>
+                        <path d="M80 78 Q80 100 80 120" stroke="#c94058" stroke-width="1.5" opacity="0.4"/>
+                    </g>
+
+                    <!-- 아래쪽 -->
+                    <g id="lowerJaw">
+                        <rect x="38" y="118" width="84" height="15" rx="4" fill="#fafafa"/>
+                        <path d="M20 128 Q80 125 140 128 Q130 150 80 155 Q30 150 20 128" fill="url(#lipGrad)"/>
+                    </g>
+
+                    <!-- 위 입술 -->
+                    <path d="M20 50 Q50 30 80 28 Q110 30 140 50 Q110 55 80 56 Q50 55 20 50" fill="url(#lipGrad)"/>
+                </svg>
             </div>
 
-            <div class="animation-area">
-                <div class="mouth-container" id="mouthContainer">
-                    <svg class="mouth-svg" viewBox="0 0 280 240">
-                        <defs>
-                            <!-- 입 내부 그라데이션 -->
-                            <radialGradient id="mouthInterior" cx="50%" cy="30%" r="70%">
-                                <stop offset="0%" stop-color="#3d2020"/>
-                                <stop offset="100%" stop-color="#1a0a0a"/>
-                            </radialGradient>
-                            <!-- 혀 그라데이션 -->
-                            <linearGradient id="tongueGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                                <stop offset="0%" stop-color="#ff7b8a"/>
-                                <stop offset="50%" stop-color="#e85a70"/>
-                                <stop offset="100%" stop-color="#c94058"/>
-                            </linearGradient>
-                            <!-- 입술 그라데이션 -->
-                            <linearGradient id="lipGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                                <stop offset="0%" stop-color="#f0b0b0"/>
-                                <stop offset="100%" stop-color="#d08080"/>
-                            </linearGradient>
-                            <!-- 아래 입술 그라데이션 -->
-                            <linearGradient id="lowerLipGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                                <stop offset="0%" stop-color="#d08080"/>
-                                <stop offset="100%" stop-color="#b06060"/>
-                            </linearGradient>
-                            <!-- 입천장 하이라이트 -->
-                            <linearGradient id="palateGlow" x1="0%" y1="0%" x2="0%" y2="100%">
-                                <stop offset="0%" stop-color="#ffeb3b"/>
-                                <stop offset="100%" stop-color="#ff9800"/>
-                            </linearGradient>
-                        </defs>
+            <div class="timer-display" id="timerDisplay">5</div>
+            <div class="timer-label" id="timerLabel">유지하세요</div>
 
-                        <!-- 얼굴 배경 (피부) -->
-                        <ellipse cx="140" cy="120" rx="130" ry="110" fill="#f5d0c5"/>
+            <div class="rep-indicator" id="repIndicator"></div>
 
-                        <!-- 입 내부 (어두운 부분) -->
-                        <ellipse cx="140" cy="130" rx="85" ry="70" fill="url(#mouthInterior)" id="mouthInterior"/>
-
-                        <!-- 윗니 -->
-                        <g id="upperTeeth">
-                            <rect x="60" y="68" width="160" height="28" rx="5" fill="#fafafa"/>
-                            <!-- 치아 구분선 -->
-                            <line x1="90" y1="68" x2="90" y2="96" stroke="#e0e0e0" stroke-width="1"/>
-                            <line x1="115" y1="68" x2="115" y2="96" stroke="#e0e0e0" stroke-width="1"/>
-                            <line x1="140" y1="68" x2="140" y2="96" stroke="#e0e0e0" stroke-width="1"/>
-                            <line x1="165" y1="68" x2="165" y2="96" stroke="#e0e0e0" stroke-width="1"/>
-                            <line x1="190" y1="68" x2="190" y2="96" stroke="#e0e0e0" stroke-width="1"/>
-                        </g>
-
-                        <!-- 입천장 -->
-                        <path d="M70 85 Q140 60 210 85 Q140 100 70 85" fill="#4a2828" id="palate"/>
-
-                        <!-- 입천장 하이라이트 (혀 올릴 때 표시) -->
-                        <path d="M85 82 Q140 65 195 82" stroke="url(#palateGlow)" stroke-width="6" fill="none"
-                              stroke-linecap="round" id="palateHighlight"/>
-
-                        <!-- 혀 -->
-                        <g id="tongue">
-                            <path d="M80 150
-                                     Q80 130 100 125
-                                     Q120 120 140 118
-                                     Q160 120 180 125
-                                     Q200 130 200 150
-                                     Q200 180 180 195
-                                     Q160 210 140 212
-                                     Q120 210 100 195
-                                     Q80 180 80 150"
-                                  fill="url(#tongueGradient)"/>
-                            <!-- 혀 중앙선 -->
-                            <path d="M140 125 Q140 160 140 195" stroke="#c94058" stroke-width="2" opacity="0.5"/>
-                            <!-- 혀 질감 -->
-                            <ellipse cx="120" cy="155" rx="15" ry="8" fill="#ff8a95" opacity="0.3"/>
-                            <ellipse cx="160" cy="155" rx="15" ry="8" fill="#ff8a95" opacity="0.3"/>
-                        </g>
-
-                        <!-- 아래쪽 (아랫니 + 아래 입술) -->
-                        <g id="lowerJaw">
-                            <!-- 아랫니 -->
-                            <rect x="65" y="185" width="150" height="22" rx="5" fill="#fafafa"/>
-                            <line x1="95" y1="185" x2="95" y2="207" stroke="#e0e0e0" stroke-width="1"/>
-                            <line x1="120" y1="185" x2="120" y2="207" stroke="#e0e0e0" stroke-width="1"/>
-                            <line x1="140" y1="185" x2="140" y2="207" stroke="#e0e0e0" stroke-width="1"/>
-                            <line x1="160" y1="185" x2="160" y2="207" stroke="#e0e0e0" stroke-width="1"/>
-                            <line x1="185" y1="185" x2="185" y2="207" stroke="#e0e0e0" stroke-width="1"/>
-
-                            <!-- 아래 입술 -->
-                            <path d="M30 200
-                                     Q80 195 140 195
-                                     Q200 195 250 200
-                                     Q230 235 140 240
-                                     Q50 235 30 200"
-                                  fill="url(#lowerLipGradient)"/>
-                            <!-- 아래 입술 하이라이트 -->
-                            <path d="M80 210 Q140 215 200 210" stroke="#e8a0a0" stroke-width="3" fill="none" opacity="0.5"/>
-                        </g>
-
-                        <!-- 위 입술 -->
-                        <g id="upperLip">
-                            <path d="M30 75
-                                     Q50 40 140 35
-                                     Q230 40 250 75
-                                     Q200 80 140 82
-                                     Q80 80 30 75"
-                                  fill="url(#lipGradient)"/>
-                            <!-- 인중 -->
-                            <path d="M140 35 L135 55 L140 60 L145 55 Z" fill="#e8b0b0"/>
-                            <!-- 입술 하이라이트 -->
-                            <ellipse cx="140" cy="55" rx="30" ry="8" fill="#ffcccc" opacity="0.4"/>
-                        </g>
-
-                        <!-- 입꼬리 그림자 -->
-                        <ellipse cx="45" cy="130" rx="12" ry="20" fill="#e0b0a0" opacity="0.5"/>
-                        <ellipse cx="235" cy="130" rx="12" ry="20" fill="#e0b0a0" opacity="0.5"/>
-                    </svg>
-                </div>
-
-                <div class="exercise-name" id="exerciseStatus">준비</div>
-                <div class="exercise-instruction" id="instruction">
-                    혀를 입천장에 붙이고 5초 유지하세요
-                </div>
-            </div>
-
-            <div class="timer-section">
-                <div class="timer-display" id="timerDisplay">5</div>
-
-                <div class="progress-container">
-                    <div class="progress-bar" id="progressBar" style="width: 0%"></div>
-                </div>
-                <div class="progress-text" id="progressText">운동 1/3 • 반복 1/10</div>
-            </div>
-
-            <div class="rep-counter" id="repCounter">
-                <!-- 반복 도트들이 여기에 들어감 -->
-            </div>
-
-            <button class="btn btn-success" id="successBtn">
-                ✔ 완료
-            </button>
+            <button class="btn-done hidden" id="doneBtn">완료</button>
         </div>
 
-        <!-- 완료 화면 -->
-        <div class="complete-screen" id="completeScreen">
-            <div class="complete-icon">🎉</div>
-            <h2 class="complete-title">훈련 완료!</h2>
-            <p class="complete-stats" id="completeStats">
-                오늘도 잘 했어요!<br>
-                총 소요 시간: <span id="totalTime">8분 30초</span>
-            </p>
-            <button class="btn btn-primary" id="restartBtn">
-                다시 하기
-            </button>
+        <!-- ========== 완료 화면 ========== -->
+        <div class="glass-card complete-screen" id="completeScreen">
+            <div class="complete-visual">✓</div>
+            <h2 class="complete-title">훈련 완료</h2>
+            <p class="complete-subtitle">오늘도 잘 했어요</p>
+
+            <div class="stat-row">
+                <div class="stat-item">
+                    <div class="stat-value" id="totalTime">0:00</div>
+                    <div class="stat-label">소요 시간</div>
+                </div>
+                <div class="stat-item">
+                    <div class="stat-value" id="totalReps">35</div>
+                    <div class="stat-label">총 반복</div>
+                </div>
+                <div class="stat-item">
+                    <div class="stat-value" id="newStreak">1</div>
+                    <div class="stat-label">연속일</div>
+                </div>
+            </div>
+
+            <button class="btn-restart" id="restartBtn">다시 하기</button>
         </div>
     </div>
 
-    <!-- 카운트다운 오버레이 -->
+    <!-- 카운트다운 -->
     <div class="countdown-overlay" id="countdownOverlay">
         <div class="countdown-number" id="countdownNumber">3</div>
     </div>
 
     <script>
-        // ==================== 설정 ====================
+        // ========== 설정 ==========
         const ROUTINE = [
-            {
-                name: "혀 올리기",
-                hold: 5,
-                reps: 10,
-                rest: 2,
-                instruction: "혀 전체를 입천장에 붙이고\n유지하세요",
-                animation: "up"
-            },
-            {
-                name: "혀 내밀기",
-                hold: 3,
-                reps: 10,
-                rest: 2,
-                instruction: "혀를 최대한 앞으로 내밀고\n유지하세요",
-                animation: "out"
-            },
-            {
-                name: "혀 클릭",
-                hold: 0,
-                reps: 15,
-                rest: 1,
-                instruction: "혀를 입천장에 붙였다\n'똑' 소리내며 떼세요",
-                animation: "click"
-            }
+            { name: "혀 올리기", hold: 5, reps: 10, rest: 2, animation: "up" },
+            { name: "혀 내밀기", hold: 3, reps: 10, rest: 2, animation: "out" },
+            { name: "혀 클릭", hold: 0, reps: 15, rest: 1, animation: "click" }
         ];
 
-        // ==================== 상태 ====================
+        const TOTAL_REPS = ROUTINE.reduce((sum, e) => sum + e.reps, 0);
+        const CIRCLE_LENGTH = 666; // 2 * PI * 106
+
+        // ========== 상태 ==========
         let state = {
             currentExercise: 0,
             currentRep: 0,
-            isHolding: false,
-            isResting: false,
             timerValue: 0,
             timerInterval: null,
             voiceEnabled: true,
-            startTime: null,
-            isPaused: false
+            startTime: null
         };
 
-        // ==================== DOM 요소 ====================
-        const elements = {
-            startScreen: document.getElementById('startScreen'),
-            trainingScreen: document.getElementById('trainingScreen'),
-            completeScreen: document.getElementById('completeScreen'),
-            countdownOverlay: document.getElementById('countdownOverlay'),
-            countdownNumber: document.getElementById('countdownNumber'),
-            startBtn: document.getElementById('startBtn'),
-            successBtn: document.getElementById('successBtn'),
-            restartBtn: document.getElementById('restartBtn'),
-            voiceToggle: document.getElementById('voiceToggle'),
-            currentExerciseTitle: document.getElementById('currentExerciseTitle'),
-            exerciseStatus: document.getElementById('exerciseStatus'),
-            instruction: document.getElementById('instruction'),
-            timerDisplay: document.getElementById('timerDisplay'),
-            progressBar: document.getElementById('progressBar'),
-            progressText: document.getElementById('progressText'),
-            repCounter: document.getElementById('repCounter'),
-            mouthContainer: document.getElementById('mouthContainer'),
-            tongue: document.getElementById('tongue'),
-            lowerJaw: document.getElementById('lowerJaw'),
-            palateHighlight: document.getElementById('palateHighlight'),
-            streakCount: document.getElementById('streakCount'),
-            totalTime: document.getElementById('totalTime')
+        // ========== DOM ==========
+        const $ = id => document.getElementById(id);
+
+        const el = {
+            startScreen: $('startScreen'),
+            trainingScreen: $('trainingScreen'),
+            completeScreen: $('completeScreen'),
+            countdownOverlay: $('countdownOverlay'),
+            countdownNumber: $('countdownNumber'),
+            startBtn: $('startBtn'),
+            doneBtn: $('doneBtn'),
+            restartBtn: $('restartBtn'),
+            voiceToggle: $('voiceToggle'),
+            exerciseNum: $('exerciseNum'),
+            exerciseName: $('exerciseName'),
+            timerDisplay: $('timerDisplay'),
+            timerLabel: $('timerLabel'),
+            repIndicator: $('repIndicator'),
+            progressCircle: $('progressCircle'),
+            mouthContainer: $('mouthContainer'),
+            tongue: $('tongue'),
+            palateGlow: $('palateGlow'),
+            streakCount: $('streakCount'),
+            totalTime: $('totalTime'),
+            totalReps: $('totalReps'),
+            newStreak: $('newStreak')
         };
 
-        // ==================== 음성 합성 ====================
+        // ========== 음성 ==========
         function speak(text) {
             if (!state.voiceEnabled) return;
-
             window.speechSynthesis.cancel();
-
-            const utterance = new SpeechSynthesisUtterance(text);
-            utterance.lang = 'ko-KR';
-            utterance.rate = 1.0;
-            utterance.pitch = 1.0;
-
+            const u = new SpeechSynthesisUtterance(text);
+            u.lang = 'ko-KR';
+            u.rate = 1.0;
             const voices = window.speechSynthesis.getVoices();
-            const koreanVoice = voices.find(v => v.lang.includes('ko'));
-            if (koreanVoice) {
-                utterance.voice = koreanVoice;
-            }
-
-            window.speechSynthesis.speak(utterance);
+            const ko = voices.find(v => v.lang.includes('ko'));
+            if (ko) u.voice = ko;
+            window.speechSynthesis.speak(u);
         }
 
-        window.speechSynthesis.onvoiceschanged = () => {
-            window.speechSynthesis.getVoices();
-        };
+        window.speechSynthesis.onvoiceschanged = () => window.speechSynthesis.getVoices();
 
-        // ==================== 연속일 관리 ====================
+        // ========== 연속일 ==========
         function loadStreak() {
             const data = JSON.parse(localStorage.getItem('tongueTraining') || '{}');
             const today = new Date().toDateString();
             const yesterday = new Date(Date.now() - 86400000).toDateString();
-
-            if (data.lastDate === today) {
+            if (data.lastDate === today || data.lastDate === yesterday) {
                 return data.streak || 1;
-            } else if (data.lastDate === yesterday) {
-                return data.streak || 1;
-            } else {
-                return 0;
             }
+            return 0;
         }
 
         function saveStreak() {
             const data = JSON.parse(localStorage.getItem('tongueTraining') || '{}');
             const today = new Date().toDateString();
             const yesterday = new Date(Date.now() - 86400000).toDateString();
-
             let newStreak = 1;
             if (data.lastDate === yesterday) {
                 newStreak = (data.streak || 0) + 1;
             } else if (data.lastDate === today) {
                 newStreak = data.streak || 1;
             }
-
-            localStorage.setItem('tongueTraining', JSON.stringify({
-                lastDate: today,
-                streak: newStreak
-            }));
-
+            localStorage.setItem('tongueTraining', JSON.stringify({ lastDate: today, streak: newStreak }));
             return newStreak;
         }
 
-        // ==================== UI 업데이트 ====================
-        function updateRepDots(exercise, currentRep) {
-            const container = elements.repCounter;
-            container.innerHTML = '';
-
+        // ========== UI ==========
+        function updateRepDots(exercise, current) {
+            el.repIndicator.innerHTML = '';
             for (let i = 0; i < exercise.reps; i++) {
                 const dot = document.createElement('div');
                 dot.className = 'rep-dot';
-                if (i < currentRep) {
-                    dot.classList.add('completed');
-                } else if (i === currentRep) {
-                    dot.classList.add('current');
-                }
-                container.appendChild(dot);
+                if (i < current) dot.classList.add('completed');
+                else if (i === current) dot.classList.add('current');
+                el.repIndicator.appendChild(dot);
             }
         }
 
-        function updateProgress() {
-            const exercise = ROUTINE[state.currentExercise];
-            const totalReps = ROUTINE.reduce((sum, e) => sum + e.reps, 0);
-            const completedReps = ROUTINE.slice(0, state.currentExercise).reduce((sum, e) => sum + e.reps, 0) + state.currentRep;
-            const progress = (completedReps / totalReps) * 100;
-
-            elements.progressBar.style.width = `${progress}%`;
-            elements.progressText.textContent = `운동 ${state.currentExercise + 1}/3 • 반복 ${state.currentRep + 1}/${exercise.reps}`;
+        function updateProgress(value, max) {
+            const offset = CIRCLE_LENGTH - (value / max) * CIRCLE_LENGTH;
+            el.progressCircle.style.strokeDashoffset = offset;
         }
 
-        function setTongueAnimation(type) {
-            const tongue = elements.tongue;
-            const container = elements.mouthContainer;
+        function setAnimation(type) {
+            const tongue = el.tongue;
+            const container = el.mouthContainer;
 
-            // 모든 클래스 제거
             tongue.classList.remove('up', 'out', 'click');
             container.classList.remove('mouth-open', 'tongue-up');
 
@@ -912,26 +889,22 @@
             } else if (type === 'click') {
                 container.classList.add('mouth-open');
                 tongue.classList.add('click');
-                // 클릭 애니메이션 후 원위치
-                setTimeout(() => {
-                    tongue.classList.remove('click');
-                }, 400);
+                setTimeout(() => tongue.classList.remove('click'), 400);
             }
         }
 
-        // ==================== 타이머 로직 ====================
+        // ========== 타이머 ==========
         function startHoldTimer(seconds, onComplete) {
             state.timerValue = seconds;
-            state.isHolding = true;
-
-            elements.timerDisplay.textContent = seconds;
-            elements.timerDisplay.classList.add('counting');
-            elements.timerDisplay.classList.remove('rest');
+            el.timerDisplay.textContent = seconds;
+            el.timerLabel.textContent = '유지하세요';
+            updateProgress(seconds, seconds);
 
             clearInterval(state.timerInterval);
             state.timerInterval = setInterval(() => {
                 state.timerValue--;
-                elements.timerDisplay.textContent = state.timerValue;
+                el.timerDisplay.textContent = state.timerValue;
+                updateProgress(state.timerValue, seconds);
 
                 if (state.timerValue <= 3 && state.timerValue > 0) {
                     speak(state.timerValue.toString());
@@ -939,7 +912,6 @@
 
                 if (state.timerValue <= 0) {
                     clearInterval(state.timerInterval);
-                    state.isHolding = false;
                     onComplete();
                 }
             }, 1000);
@@ -947,103 +919,82 @@
 
         function startRestTimer(seconds, onComplete) {
             state.timerValue = seconds;
-            state.isResting = true;
-
-            elements.exerciseStatus.textContent = '쉬기';
-            elements.timerDisplay.textContent = seconds;
-            elements.timerDisplay.classList.remove('counting');
-            elements.timerDisplay.classList.add('rest');
-            setTongueAnimation(null);
-
+            el.timerDisplay.textContent = seconds;
+            el.timerLabel.textContent = '쉬세요';
+            setAnimation(null);
             speak('쉬세요');
+            updateProgress(0, 1);
 
             clearInterval(state.timerInterval);
             state.timerInterval = setInterval(() => {
                 state.timerValue--;
-                elements.timerDisplay.textContent = state.timerValue;
+                el.timerDisplay.textContent = state.timerValue;
 
                 if (state.timerValue <= 0) {
                     clearInterval(state.timerInterval);
-                    state.isResting = false;
                     onComplete();
                 }
             }, 1000);
         }
 
-        // ==================== 운동 로직 ====================
+        // ========== 운동 로직 ==========
         function startExercise() {
-            const exercise = ROUTINE[state.currentExercise];
-
-            elements.currentExerciseTitle.textContent = exercise.name;
-            elements.instruction.textContent = exercise.instruction;
-            updateRepDots(exercise, state.currentRep);
-            updateProgress();
-
-            speak(`${exercise.name} 시작`);
-
-            setTimeout(() => {
-                doRep();
-            }, 1500);
+            const ex = ROUTINE[state.currentExercise];
+            el.exerciseNum.textContent = state.currentExercise + 1;
+            el.exerciseName.textContent = ex.name;
+            updateRepDots(ex, state.currentRep);
+            speak(`${ex.name} 시작`);
+            setTimeout(doRep, 1500);
         }
 
         function doRep() {
-            const exercise = ROUTINE[state.currentExercise];
-
-            if (state.currentRep >= exercise.reps) {
+            const ex = ROUTINE[state.currentExercise];
+            if (state.currentRep >= ex.reps) {
                 nextExercise();
                 return;
             }
 
-            updateRepDots(exercise, state.currentRep);
-            updateProgress();
+            updateRepDots(ex, state.currentRep);
 
-            if (exercise.hold > 0) {
-                elements.exerciseStatus.textContent = '유지';
-                setTongueAnimation(exercise.animation);
-                speak(exercise.instruction.split('\n')[0]);
-
-                elements.successBtn.classList.add('hidden');
-
-                startHoldTimer(exercise.hold, () => {
+            if (ex.hold > 0) {
+                el.doneBtn.classList.add('hidden');
+                setAnimation(ex.animation);
+                speak(ex.name);
+                startHoldTimer(ex.hold, () => {
                     speak('좋아요');
                     state.currentRep++;
-
-                    if (state.currentRep < exercise.reps) {
-                        startRestTimer(exercise.rest, doRep);
+                    if (state.currentRep < ex.reps) {
+                        startRestTimer(ex.rest, doRep);
                     } else {
-                        setTimeout(() => nextExercise(), 500);
+                        setTimeout(nextExercise, 500);
                     }
                 });
             } else {
-                elements.exerciseStatus.textContent = '클릭!';
-                elements.timerDisplay.textContent = `${state.currentRep + 1}`;
-                elements.timerDisplay.classList.remove('counting', 'rest');
-
+                // 클릭 운동
+                el.timerDisplay.textContent = state.currentRep + 1;
+                el.timerLabel.textContent = '클릭하세요';
+                updateProgress(state.currentRep, ex.reps);
                 speak('클릭');
-                setTongueAnimation('click');
-
-                elements.successBtn.classList.remove('hidden');
+                setAnimation('click');
+                el.doneBtn.classList.remove('hidden');
             }
         }
 
-        function handleSuccessClick() {
-            const exercise = ROUTINE[state.currentExercise];
-
-            if (exercise.hold === 0) {
-                setTongueAnimation('click');
+        function handleDoneClick() {
+            const ex = ROUTINE[state.currentExercise];
+            if (ex.hold === 0) {
+                setAnimation('click');
                 state.currentRep++;
-
-                if (state.currentRep < exercise.reps) {
-                    updateRepDots(exercise, state.currentRep);
-                    updateProgress();
-                    elements.timerDisplay.textContent = `${state.currentRep + 1}`;
-
+                if (state.currentRep < ex.reps) {
+                    updateRepDots(ex, state.currentRep);
+                    el.timerDisplay.textContent = state.currentRep + 1;
+                    updateProgress(state.currentRep, ex.reps);
                     setTimeout(() => {
                         speak('클릭');
-                        setTongueAnimation('click');
-                    }, exercise.rest * 1000);
+                        setAnimation('click');
+                    }, ex.rest * 1000);
                 } else {
-                    elements.successBtn.classList.add('hidden');
+                    el.doneBtn.classList.add('hidden');
                     nextExercise();
                 }
             }
@@ -1056,26 +1007,21 @@
             if (state.currentExercise >= ROUTINE.length) {
                 completeTraining();
             } else {
-                const nextEx = ROUTINE[state.currentExercise];
-                speak(`다음 운동, ${nextEx.name}`);
-
-                setTimeout(() => {
-                    startExercise();
-                }, 2000);
+                speak(`다음 운동, ${ROUTINE[state.currentExercise].name}`);
+                setTimeout(startExercise, 2000);
             }
         }
 
-        // ==================== 시작/완료 ====================
+        // ========== 시작/완료 ==========
         function showCountdown(callback) {
-            elements.countdownOverlay.classList.add('show');
+            el.countdownOverlay.classList.add('show');
             let count = 3;
 
             function tick() {
-                elements.countdownNumber.textContent = count;
-                elements.countdownNumber.style.animation = 'none';
-                elements.countdownNumber.offsetHeight;
-                elements.countdownNumber.style.animation = 'countdownPop 1s ease';
-
+                el.countdownNumber.textContent = count;
+                el.countdownNumber.style.animation = 'none';
+                el.countdownNumber.offsetHeight;
+                el.countdownNumber.style.animation = 'countPop 1s ease';
                 speak(count.toString());
 
                 if (count > 1) {
@@ -1083,13 +1029,12 @@
                     setTimeout(tick, 1000);
                 } else {
                     setTimeout(() => {
-                        elements.countdownOverlay.classList.remove('show');
+                        el.countdownOverlay.classList.remove('show');
                         speak('시작!');
                         callback();
                     }, 1000);
                 }
             }
-
             tick();
         }
 
@@ -1098,66 +1043,60 @@
             state.currentRep = 0;
             state.startTime = Date.now();
 
-            elements.startScreen.classList.add('hidden');
-            elements.completeScreen.classList.remove('show');
-            elements.trainingScreen.classList.add('show');
+            el.startScreen.classList.add('hidden');
+            el.completeScreen.classList.remove('show');
+            el.trainingScreen.classList.add('show');
 
-            showCountdown(() => {
-                startExercise();
-            });
+            showCountdown(startExercise);
         }
 
         function completeTraining() {
             clearInterval(state.timerInterval);
 
             const elapsed = Math.floor((Date.now() - state.startTime) / 1000);
-            const minutes = Math.floor(elapsed / 60);
-            const seconds = elapsed % 60;
+            const min = Math.floor(elapsed / 60);
+            const sec = elapsed % 60;
 
-            elements.totalTime.textContent = `${minutes}분 ${seconds}초`;
+            el.totalTime.textContent = `${min}:${sec.toString().padStart(2, '0')}`;
+            el.totalReps.textContent = TOTAL_REPS;
 
-            const newStreak = saveStreak();
-            elements.streakCount.textContent = newStreak;
+            const streak = saveStreak();
+            el.newStreak.textContent = streak;
+            el.streakCount.textContent = streak;
 
-            elements.trainingScreen.classList.remove('show');
-            elements.completeScreen.classList.add('show');
+            el.trainingScreen.classList.remove('show');
+            el.completeScreen.classList.add('show');
 
             speak('훈련 완료! 잘 했어요!');
         }
 
         function resetTraining() {
             clearInterval(state.timerInterval);
-
             state.currentExercise = 0;
             state.currentRep = 0;
-            state.isHolding = false;
-            state.isResting = false;
 
-            elements.completeScreen.classList.remove('show');
-            elements.trainingScreen.classList.remove('show');
-            elements.startScreen.classList.remove('hidden');
+            el.completeScreen.classList.remove('show');
+            el.trainingScreen.classList.remove('show');
+            el.startScreen.classList.remove('hidden');
 
-            setTongueAnimation(null);
+            setAnimation(null);
+            updateProgress(0, 1);
         }
 
-        // ==================== 이벤트 리스너 ====================
-        elements.startBtn.addEventListener('click', startTraining);
-        elements.successBtn.addEventListener('click', handleSuccessClick);
-        elements.restartBtn.addEventListener('click', resetTraining);
+        // ========== 이벤트 ==========
+        el.startBtn.addEventListener('click', startTraining);
+        el.doneBtn.addEventListener('click', handleDoneClick);
+        el.restartBtn.addEventListener('click', resetTraining);
 
-        elements.voiceToggle.addEventListener('click', () => {
+        el.voiceToggle.addEventListener('click', () => {
             state.voiceEnabled = !state.voiceEnabled;
-            elements.voiceToggle.textContent = state.voiceEnabled ? '🔊' : '🔇';
-
-            if (!state.voiceEnabled) {
-                window.speechSynthesis.cancel();
-            }
+            el.voiceToggle.textContent = state.voiceEnabled ? '🔊' : '🔇';
+            if (!state.voiceEnabled) window.speechSynthesis.cancel();
         });
 
-        // ==================== 초기화 ====================
+        // ========== 초기화 ==========
         function init() {
-            const streak = loadStreak();
-            elements.streakCount.textContent = streak;
+            el.streakCount.textContent = loadStreak();
             window.speechSynthesis.getVoices();
         }
 

--- a/tongue-training.html
+++ b/tongue-training.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>혀 훈련</title>
+    <!-- Spline 3D Runtime -->
+    <script type="module" src="https://unpkg.com/@splinetool/viewer@1.9.82/build/spline-viewer.js"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
@@ -577,6 +579,67 @@
             display: none !important;
         }
 
+        /* ========== Spline 3D ========== */
+        .spline-container {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 200px;
+            height: 200px;
+            border-radius: 50%;
+            overflow: hidden;
+        }
+
+        .spline-container spline-viewer {
+            width: 100%;
+            height: 100%;
+            --spline-viewer-background: transparent;
+        }
+
+        .spline-loading {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 12px;
+            z-index: 5;
+        }
+
+        .spline-loading .spinner {
+            width: 40px;
+            height: 40px;
+            border: 3px solid rgba(255, 255, 255, 0.1);
+            border-top-color: var(--accent-1);
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .spline-loading span {
+            font-size: 0.75rem;
+            color: var(--text-tertiary);
+        }
+
+        .spline-fallback {
+            display: none;
+        }
+
+        .spline-fallback.show {
+            display: block;
+        }
+
+        .spline-container.loaded + .spline-fallback,
+        .spline-container.loaded ~ .spline-loading {
+            display: none;
+        }
+
         /* 반응형 */
         @media (max-width: 420px) {
             .glass-card {
@@ -673,8 +736,28 @@
                             stroke-dasharray="666" stroke-dashoffset="666"/>
                 </svg>
 
-                <!-- 입 SVG -->
-                <svg class="mouth-svg" viewBox="0 0 160 160">
+                <!-- Spline 3D 입/혀 (사용자가 URL 제공 시 활성화) -->
+                <div class="spline-container" id="splineContainer">
+                    <!--
+                    ⚠️ 플레이스홀더: 아래 URL을 실제 Spline 씬 URL로 교체하세요
+                    예: url="https://prod.spline.design/YOUR-SCENE-ID/scene.splinecode"
+                    -->
+                    <spline-viewer
+                        id="splineViewer"
+                        url=""
+                        loading-anim-type="spinner-small-light"
+                        events-target="local">
+                    </spline-viewer>
+                </div>
+
+                <!-- 로딩 상태 -->
+                <div class="spline-loading" id="splineLoading" style="display: none;">
+                    <div class="spinner"></div>
+                    <span>3D 로딩 중...</span>
+                </div>
+
+                <!-- 폴백: SVG 입 (Spline 로드 실패 또는 URL 없을 때) -->
+                <svg class="mouth-svg spline-fallback show" id="mouthSvgFallback" viewBox="0 0 160 160">
                     <defs>
                         <radialGradient id="mouthBg" cx="50%" cy="40%" r="60%">
                             <stop offset="0%" stop-color="#2d1a2d"/>
@@ -785,7 +868,9 @@
             timerValue: 0,
             timerInterval: null,
             voiceEnabled: true,
-            startTime: null
+            startTime: null,
+            splineApp: null,       // Spline Application 인스턴스
+            useSpline: false       // Spline 사용 여부
         };
 
         // ========== DOM ==========
@@ -813,7 +898,11 @@
             streakCount: $('streakCount'),
             totalTime: $('totalTime'),
             totalReps: $('totalReps'),
-            newStreak: $('newStreak')
+            newStreak: $('newStreak'),
+            splineViewer: $('splineViewer'),
+            splineContainer: $('splineContainer'),
+            splineLoading: $('splineLoading'),
+            mouthSvgFallback: $('mouthSvgFallback')
         };
 
         // ========== 음성 ==========
@@ -874,6 +963,19 @@
         }
 
         function setAnimation(type) {
+            // Spline 3D 애니메이션 (활성화된 경우)
+            if (state.useSpline && state.splineApp) {
+                try {
+                    // Spline Variable로 혀 상태 전달
+                    // 씬에서 "tongueState" 변수를 설정해야 함
+                    // 값: "idle" | "up" | "out" | "click"
+                    state.splineApp.setVariable('tongueState', type || 'idle');
+                } catch (e) {
+                    console.warn('Spline setVariable 실패:', e);
+                }
+            }
+
+            // SVG 폴백 애니메이션 (항상 실행 - 동기화용)
             const tongue = el.tongue;
             const container = el.mouthContainer;
 
@@ -1094,10 +1196,73 @@
             if (!state.voiceEnabled) window.speechSynthesis.cancel();
         });
 
+        // ========== Spline 초기화 ==========
+        async function initSpline() {
+            const viewer = el.splineViewer;
+            const url = viewer.getAttribute('url');
+
+            // URL이 비어있으면 SVG 폴백 사용
+            if (!url) {
+                console.log('Spline URL 없음 → SVG 폴백 사용');
+                el.splineContainer.style.display = 'none';
+                el.mouthSvgFallback.classList.add('show');
+                return;
+            }
+
+            // 로딩 시작
+            el.splineLoading.style.display = 'flex';
+            el.mouthSvgFallback.classList.remove('show');
+
+            try {
+                // Spline 로드 이벤트 리스너
+                viewer.addEventListener('load', (event) => {
+                    console.log('Spline 씬 로드 완료');
+                    state.splineApp = event.target;
+                    state.useSpline = true;
+
+                    el.splineContainer.classList.add('loaded');
+                    el.splineLoading.style.display = 'none';
+                    el.mouthSvgFallback.classList.remove('show');
+
+                    // 초기 상태 설정
+                    try {
+                        state.splineApp.setVariable('tongueState', 'idle');
+                    } catch (e) {
+                        console.warn('초기 상태 설정 실패:', e);
+                    }
+                });
+
+                // 에러 핸들링
+                viewer.addEventListener('error', (error) => {
+                    console.warn('Spline 로드 실패 → SVG 폴백:', error);
+                    el.splineLoading.style.display = 'none';
+                    el.splineContainer.style.display = 'none';
+                    el.mouthSvgFallback.classList.add('show');
+                    state.useSpline = false;
+                });
+
+                // 5초 타임아웃
+                setTimeout(() => {
+                    if (!state.useSpline) {
+                        console.log('Spline 타임아웃 → SVG 폴백');
+                        el.splineLoading.style.display = 'none';
+                        el.splineContainer.style.display = 'none';
+                        el.mouthSvgFallback.classList.add('show');
+                    }
+                }, 5000);
+
+            } catch (error) {
+                console.warn('Spline 초기화 실패:', error);
+                el.splineContainer.style.display = 'none';
+                el.mouthSvgFallback.classList.add('show');
+            }
+        }
+
         // ========== 초기화 ==========
         function init() {
             el.streakCount.textContent = loadStreak();
             window.speechSynthesis.getVoices();
+            initSpline();
         }
 
         init();

--- a/tongue-training.html
+++ b/tongue-training.html
@@ -978,6 +978,160 @@
             font-weight: 500;
         }
 
+        /* 상관관계 차트 */
+        .correlation-section {
+            margin-bottom: 24px;
+        }
+
+        .correlation-chart {
+            background: rgba(0,0,0,0.2);
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        .scatter-plot {
+            position: relative;
+            height: 140px;
+            border-left: 1px solid rgba(255,255,255,0.1);
+            border-bottom: 1px solid rgba(255,255,255,0.1);
+            margin: 8px 0 8px 24px;
+        }
+
+        .scatter-dot {
+            position: absolute;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: var(--accent-1);
+            transform: translate(-50%, 50%);
+            opacity: 0.8;
+            transition: all 0.3s;
+        }
+
+        .scatter-dot:hover {
+            transform: translate(-50%, 50%) scale(1.5);
+            opacity: 1;
+        }
+
+        .scatter-dot.good { background: var(--success); }
+        .scatter-dot.bad { background: var(--accent-3); }
+
+        .axis-label {
+            position: absolute;
+            font-size: 0.6rem;
+            color: var(--text-tertiary);
+        }
+
+        .axis-label.y {
+            left: -20px;
+            top: 50%;
+            transform: translateY(-50%) rotate(-90deg);
+            white-space: nowrap;
+        }
+
+        .axis-label.x {
+            bottom: -18px;
+            left: 50%;
+            transform: translateX(-50%);
+        }
+
+        .scatter-legend {
+            display: flex;
+            justify-content: center;
+            gap: 16px;
+            margin-top: 12px;
+            font-size: 0.7rem;
+            color: var(--text-tertiary);
+        }
+
+        .scatter-legend span {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .scatter-legend .dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+        }
+
+        /* 추천 카드 */
+        .recommendation-card {
+            background: linear-gradient(135deg, rgba(16,185,129,0.1), rgba(6,182,212,0.1));
+            border: 1px solid rgba(16,185,129,0.2);
+            border-radius: 16px;
+            padding: 16px;
+            margin-bottom: 24px;
+        }
+
+        .recommendation-header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+
+        .recommendation-title {
+            font-size: 0.9rem;
+            font-weight: 500;
+            color: var(--success);
+        }
+
+        .recommendation-content {
+            display: flex;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .optimal-time {
+            text-align: center;
+            padding: 12px 20px;
+            background: rgba(16,185,129,0.15);
+            border-radius: 12px;
+        }
+
+        .optimal-time .time {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--success);
+        }
+
+        .optimal-time .label {
+            font-size: 0.65rem;
+            color: var(--text-tertiary);
+            text-transform: uppercase;
+        }
+
+        .optimal-reason {
+            flex: 1;
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+            line-height: 1.4;
+        }
+
+        /* 데이터 내보내기 */
+        .export-section {
+            text-align: center;
+        }
+
+        .btn-export {
+            padding: 12px 24px;
+            border-radius: 12px;
+            border: 1px solid var(--glass-border);
+            background: transparent;
+            color: var(--text-secondary);
+            font-size: 0.8rem;
+            font-family: inherit;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .btn-export:hover {
+            background: rgba(255,255,255,0.05);
+            color: var(--text-primary);
+        }
+
         /* 대시보드 버튼 */
         .btn-dashboard {
             width: 44px;
@@ -1296,6 +1450,41 @@
                 </div>
             </div>
 
+            <!-- 상관관계 차트 -->
+            <div class="correlation-section">
+                <div class="section-header">
+                    <span class="section-title">수면 vs 훈련 시간</span>
+                    <span class="section-subtitle">상관관계 분석</span>
+                </div>
+                <div class="correlation-chart">
+                    <div class="scatter-plot" id="scatterPlot">
+                        <span class="axis-label y">훈련(분)</span>
+                        <span class="axis-label x">수면(시간)</span>
+                    </div>
+                    <div class="scatter-legend">
+                        <span><div class="dot" style="background: var(--success)"></div> 완주</span>
+                        <span><div class="dot" style="background: var(--accent-3)"></div> 미완주</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 최적 훈련 시간 추천 -->
+            <div class="recommendation-card" id="recommendationCard">
+                <div class="recommendation-header">
+                    <span>⏰</span>
+                    <span class="recommendation-title">오늘의 추천</span>
+                </div>
+                <div class="recommendation-content">
+                    <div class="optimal-time">
+                        <div class="time" id="optimalTime">오전 9시</div>
+                        <div class="label">최적 시간</div>
+                    </div>
+                    <div class="optimal-reason" id="optimalReason">
+                        수면 품질이 좋을 때 아침 훈련 완주율이 높아요. 지금 시작해보세요!
+                    </div>
+                </div>
+            </div>
+
             <!-- 인사이트 -->
             <div class="insight-card" id="insightCard">
                 <div class="insight-icon">💡</div>
@@ -1304,6 +1493,11 @@
                     <span class="insight-highlight">23% 높아요</span>.
                     충분히 자고 훈련해보세요!
                 </div>
+            </div>
+
+            <!-- 데이터 내보내기 -->
+            <div class="export-section">
+                <button class="btn-export" id="exportBtn">📥 데이터 내보내기 (JSON)</button>
             </div>
         </div>
     </div>
@@ -1381,7 +1575,12 @@
             chartLabels: $('chartLabels'),
             weekRange: $('weekRange'),
             sleepHours: $('sleepHours'),
-            insightCard: $('insightCard')
+            insightCard: $('insightCard'),
+            scatterPlot: $('scatterPlot'),
+            recommendationCard: $('recommendationCard'),
+            optimalTime: $('optimalTime'),
+            optimalReason: $('optimalReason'),
+            exportBtn: $('exportBtn')
         };
 
         // ========== 음성 ==========
@@ -1476,6 +1675,8 @@
             renderHeatmap(history);
             renderWeeklyChart(history);
             renderSleepInput();
+            renderCorrelationChart(history);
+            renderRecommendation(history);
             renderInsight(history);
         }
 
@@ -1706,6 +1907,111 @@
                     <span class="insight-highlight">멋져요! 🎉</span>
                 `;
             }
+        }
+
+        function renderCorrelationChart(history) {
+            const sleepData = JSON.parse(localStorage.getItem('tongueSleep') || '{}');
+            el.scatterPlot.querySelectorAll('.scatter-dot').forEach(d => d.remove());
+
+            // 수면 데이터가 있는 세션만 필터링
+            const dataPoints = history.filter(s => {
+                const sleep = sleepData[s.date];
+                return sleep && sleep.hours;
+            }).map(s => {
+                const sleep = sleepData[s.date];
+                const sleepHours = parseFloat(sleep.hours) || 0;
+                const trainingMin = Math.round((s.duration || 0) / 60);
+                const completed = (s.reps || 0) >= TOTAL_REPS;
+                return { sleepHours, trainingMin, completed, date: s.date };
+            });
+
+            if (dataPoints.length === 0) return;
+
+            // 차트 영역: 수면 4-10시간, 훈련 0-15분
+            const minSleep = 4, maxSleep = 10;
+            const maxTraining = 15;
+            const plotWidth = el.scatterPlot.offsetWidth;
+            const plotHeight = el.scatterPlot.offsetHeight;
+
+            dataPoints.forEach(p => {
+                const x = ((Math.min(Math.max(p.sleepHours, minSleep), maxSleep) - minSleep) / (maxSleep - minSleep)) * plotWidth;
+                const y = (1 - Math.min(p.trainingMin, maxTraining) / maxTraining) * plotHeight;
+
+                const dot = document.createElement('div');
+                dot.className = 'scatter-dot ' + (p.completed ? 'good' : 'bad');
+                dot.style.left = x + 'px';
+                dot.style.bottom = (plotHeight - y) + 'px';
+                dot.title = `${p.date}\n수면: ${p.sleepHours}시간\n훈련: ${p.trainingMin}분`;
+                el.scatterPlot.appendChild(dot);
+            });
+        }
+
+        function renderRecommendation(history) {
+            const now = new Date();
+            const hour = now.getHours();
+            const sleepData = JSON.parse(localStorage.getItem('tongueSleep') || '{}');
+            const todaySleep = getTodaySleep();
+
+            // 시간대별 완주율 분석
+            const timeSlots = { morning: [], afternoon: [], evening: [] };
+            history.forEach(s => {
+                const h = new Date(s.timestamp).getHours();
+                const completed = (s.reps || 0) >= TOTAL_REPS;
+                if (h >= 5 && h < 12) timeSlots.morning.push(completed);
+                else if (h >= 12 && h < 18) timeSlots.afternoon.push(completed);
+                else timeSlots.evening.push(completed);
+            });
+
+            const getRate = arr => arr.length > 0 ? arr.filter(x => x).length / arr.length : 0;
+            const rates = {
+                morning: getRate(timeSlots.morning),
+                afternoon: getRate(timeSlots.afternoon),
+                evening: getRate(timeSlots.evening)
+            };
+
+            // 가장 높은 완주율 시간대 찾기
+            let bestTime = 'morning', bestRate = rates.morning;
+            if (rates.afternoon > bestRate) { bestTime = 'afternoon'; bestRate = rates.afternoon; }
+            if (rates.evening > bestRate) { bestTime = 'evening'; bestRate = rates.evening; }
+
+            // 추천 시간 결정
+            const timeNames = {
+                morning: '오전 9시',
+                afternoon: '오후 2시',
+                evening: '저녁 7시'
+            };
+
+            // 수면 품질에 따른 메시지
+            let reason = '';
+            if (todaySleep?.quality === 'great' || todaySleep?.quality === 'good') {
+                reason = `오늘 수면 품질이 좋아요! ${bestTime === 'morning' ? '아침' : bestTime === 'afternoon' ? '오후' : '저녁'} 훈련이 ${Math.round(bestRate * 100)}% 완주율을 보여요.`;
+            } else if (todaySleep?.quality === 'bad') {
+                reason = `피곤할 수 있어요. 컨디션 좋을 때 도전해보세요. 무리하지 마세요!`;
+            } else if (history.length < 5) {
+                reason = `아직 데이터가 부족해요. 5일 이상 훈련하면 맞춤 추천을 받을 수 있어요!`;
+            } else {
+                reason = `${bestTime === 'morning' ? '아침' : bestTime === 'afternoon' ? '오후' : '저녁'} 훈련 시 완주율이 ${Math.round(bestRate * 100)}%로 가장 높아요!`;
+            }
+
+            el.optimalTime.textContent = timeNames[bestTime];
+            el.optimalReason.textContent = reason;
+        }
+
+        function exportData() {
+            const data = {
+                exportDate: new Date().toISOString(),
+                history: getHistory(),
+                sleep: JSON.parse(localStorage.getItem('tongueSleep') || '{}'),
+                streak: JSON.parse(localStorage.getItem('tongueTraining') || '{}')
+            };
+
+            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `tongue-training-${new Date().toISOString().split('T')[0]}.json`;
+            a.click();
+            URL.revokeObjectURL(url);
         }
 
         // ========== UI ==========
@@ -1979,6 +2285,9 @@
                 saveSleep(el.sleepHours.value || '', btn.dataset.quality);
             });
         });
+
+        // 데이터 내보내기
+        el.exportBtn.addEventListener('click', exportData);
 
         // ========== Spline 초기화 ==========
         async function initSpline() {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./tests/setup.js'],
+    include: ['tests/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.js'],
+      exclude: ['src/**/*.test.js']
+    }
+  }
+});


### PR DESCRIPTION
- 3가지 운동 루틴 (혀 올리기, 혀 내밀기, 혀 클릭)
- CSS 애니메이션으로 혀 동작 시각화
- Web Speech API 음성 안내
- 타이머 및 반복 카운터
- localStorage로 연속일 저장
- 약 8분 소요, 카메라 없이 사용 가능

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a self-contained training experience in `tongue-training.html` with guided routines and progress tracking.
> 
> - Implements 3-exercise routine (`혀 올리기`, `혀 내밀기`, `혀 클릭`) with hold/rest timers and per-rep UI
> - SVG mouth visualization with CSS animations (`up`, `out`, `click`) and circular progress ring
> - Web Speech API voice guidance with toggle (`🔊/🔇`) and countdown overlay
> - Tracks total time/reps and persists streaks via `localStorage`
> - Start/training/complete screens with responsive glassmorphism UI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c09a101de81cc722008e0eaef4ee96df7481c73c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->